### PR TITLE
add get_table_mapping_as_dict method

### DIFF
--- a/examples/use_case_with_mapping.py
+++ b/examples/use_case_with_mapping.py
@@ -33,7 +33,6 @@ data = [
     }
 ]
 
-
 mapping_dict = {
     'table_name': 'user',
     'column_mappings': {
@@ -73,7 +72,6 @@ mapping_dict = {
     }
 }
 
-
 mapping = TableMapping.build_from_mapping_dict(mapping_dict)
 parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=True)
 parsed_data = parser.parse_data(data)
@@ -82,10 +80,14 @@ parsed_data = parser.parse_data(data)
 print(parser.get_mapping_by_object_path())
 print(parser.get_mapping_by_object_path("user.addresses"))
 
-
 # KCOFAC-2623 - store mapping in statefile
-table_mappings = parser.get_table_mapping()
-mapping = TableMapping.build_from_mapping_dict(table_mappings)
+table_mapping = parser.get_table_mapping()
+
+# store in state
+mapping_dict = table_mapping.as_dict()
+
+# restore from state
+mapping = TableMapping.build_from_mapping_dict(mapping_dict)
 parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=True)
 parsed = parser.parse_data(data)
 print(parsed)

--- a/examples/use_case_with_mapping.py
+++ b/examples/use_case_with_mapping.py
@@ -77,8 +77,9 @@ parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=T
 parsed_data = parser.parse_data(data)
 
 # Get user.addresses mapping KCOFAC-2624 - flatten result for debugging
-print(parser.get_mapping_by_object_path())
-print(parser.get_mapping_by_object_path("user.addresses"))
+flattened_result_tables = parser.get_table_mapping().get_table_mappings_flattened()
+print(flattened_result_tables)
+print(flattened_result_tables['addresses'])
 
 # KCOFAC-2623 - store mapping in statefile
 table_mapping = parser.get_table_mapping()

--- a/examples/use_case_with_mapping.py
+++ b/examples/use_case_with_mapping.py
@@ -27,10 +27,10 @@ data = [
 
 mapping_dict = {'table_name': 'user',
                 'column_mappings': {'id': 'id',
-                            'name': 'name',
-                            'details.weight': 'user_weight',
-                            'details.height': 'user_height',
-                            'details.hair_color': 'user_hair_color'},
+                                    'name': 'name',
+                                    'details.weight': 'user_weight',
+                                    'details.height': 'user_height',
+                                    'details.hair_color': 'user_hair_color'},
                 'primary_keys': ['id'],
                 'force_types': [],
                 'child_tables': {
@@ -48,3 +48,8 @@ mapping_dict = {'table_name': 'user',
 mapping = TableMapping.build_from_mapping_dict(mapping_dict)
 parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=False)
 parsed_data = parser.parse_data(data)
+
+table_mappings = parser.get_table_mapping_as_dict()
+for table_name, table_mapping in table_mappings.items():
+    print(f"Table name: {table_name}")
+    print(table_mapping)

--- a/examples/use_case_with_mapping.py
+++ b/examples/use_case_with_mapping.py
@@ -76,10 +76,10 @@ mapping = TableMapping.build_from_mapping_dict(mapping_dict)
 parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=True)
 parsed_data = parser.parse_data(data)
 
-# Get user.addresses mapping KCOFAC-2624 - flatten result for debugging
+# KCOFAC-2624 - flatten result for debugging
 flattened_result_tables = parser.get_table_mapping().get_table_mappings_flattened()
-print(flattened_result_tables)
-print(flattened_result_tables['addresses'])
+for mapping in flattened_result_tables:
+    print(flattened_result_tables[mapping].as_dict())
 
 # KCOFAC-2623 - store mapping in statefile
 table_mapping = parser.get_table_mapping()

--- a/examples/use_case_with_mapping.py
+++ b/examples/use_case_with_mapping.py
@@ -13,43 +13,79 @@ data = [
             {
                 "index": 1,
                 "street": "Blossom Avenue",
-                "country": "United Kingdom"
+                "country": "United Kingdom",
+                "coordinates": {
+                    "latitude": 51.509865,
+                    "longitude": -0.118092
+                }
             },
             {
                 "index": 2,
                 "street": "Whiteheaven Mansions",
                 "city": "London",
-                "country": "United Kingdom"
+                "country": "United Kingdom",
+                "coordinates": {
+                    "latitude": 51.509865,
+                    "longitude": -0.118092
+                }
             }
         ]
     }
 ]
 
-mapping_dict = {'table_name': 'user',
-                'column_mappings': {'id': 'id',
-                                    'name': 'name',
-                                    'details.weight': 'user_weight',
-                                    'details.height': 'user_height',
-                                    'details.hair_color': 'user_hair_color'},
-                'primary_keys': ['id'],
-                'force_types': [],
-                'child_tables': {
-                    'addresses': {'table_name': 'addresses',
-                                  'column_mappings': {
-                                      'user_id': 'user_id',
-                                      'index': 'index',
-                                      'street': 'street',
-                                      'country': 'country',
-                                      'city': 'city'},
-                                  'primary_keys': ['user_id', 'index'],
-                                  'force_types': [],
-                                  'child_tables': {}}}}
+
+mapping_dict = {
+    'table_name': 'user',
+    'column_mappings': {
+        'id': 'id',
+        'name': 'name',
+        'details.weight': 'user_weight',
+        'details.height': 'user_height',
+        'details.hair_color': 'user_hair_color'
+    },
+    'primary_keys': ['id'],
+    'force_types': [],
+    'child_tables': {
+        'addresses': {
+            'table_name': 'addresses',
+            'column_mappings': {
+                'user_id': 'user_id',
+                'index': 'index',
+                'street': 'street',
+                'country': 'country',
+                'city': 'city'
+            },
+            'primary_keys': ['user_id', 'index'],
+            'force_types': [],
+            'child_tables': {
+                'coordinates': {
+                    'table_name': 'coordinates',
+                    'column_mappings': {
+                        'latitude': 'latitude',
+                        'longitude': 'longitude'
+                    },
+                    'primary_keys': [],
+                    'force_types': [],
+                    'child_tables': {}
+                }
+            }
+        }
+    }
+}
+
 
 mapping = TableMapping.build_from_mapping_dict(mapping_dict)
-parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=False)
+parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=True)
 parsed_data = parser.parse_data(data)
 
-table_mappings = parser.get_table_mapping_as_dict()
-for table_name, table_mapping in table_mappings.items():
-    print(f"Table name: {table_name}")
-    print(table_mapping)
+# Get user.addresses mapping KCOFAC-2624 - flatten result for debugging
+print(parser.get_mapping_by_object_path())
+print(parser.get_mapping_by_object_path("user.addresses"))
+
+
+# KCOFAC-2623 - store mapping in statefile
+table_mappings = parser.get_table_mapping()
+mapping = TableMapping.build_from_mapping_dict(table_mappings)
+parser = Parser(main_table_name="user", table_mapping=mapping, analyze_further=True)
+parsed = parser.parse_data(data)
+print(parsed)

--- a/src/keboola/json_to_csv/analyzer.py
+++ b/src/keboola/json_to_csv/analyzer.py
@@ -50,7 +50,7 @@ class Analyzer:
         if table_mapping:
             self.update_with_table_mapping(table_mapping, None)
 
-    def get_mapping_dict_fom_structure(self):
+    def get_mapping_dict_fom_structure(self) -> dict:
         return self._get_table_mapping_of_node_hierarchy()
 
     def analyze_object(self, path_to_object: List[Union[Any, str]], name: str, value: Any) -> None:
@@ -376,6 +376,7 @@ class Analyzer:
             child_tables.update(child_child_tables)
             force_types.extend(child_force_types)
             primary_keys.extend(child_primary_keys)
+
         return {"table_name": table_name,
                 "column_mappings": columns,
                 "primary_keys": primary_keys,
@@ -395,37 +396,15 @@ class Analyzer:
                 force_types.append(child_name)
             if child_node.is_primary_key:
                 primary_keys.append(child_name)
-        if child_node.data_type in [NodeType.LIST, NodeType.LIST_OF_SCALARS, NodeType.LIST_OF_DICTS]:
+        if child_node.data_type in [NodeType.LIST, NodeType.LIST_OF_SCALARS, NodeType.LIST_OF_DICTS, NodeType.DICT]:
             child_tables[child_name] = self._get_table_mapping_of_node_hierarchy(
                 node_hierarchy=node_hierarchy.get("children").get(child_name))
         if child_node.data_type == NodeType.DICT:
-            child_columns, child_child_tables, child_primary_keys, child_force_types = self._get_table_mapping_of_dict_node(
-                node_hierarchy.get("children").get(child_name))
-            columns.update(child_columns)
-            child_tables.update(child_child_tables)
-            force_types.extend(child_force_types)
-            primary_keys.extend(child_primary_keys)
+            columns.update(child_tables[child_name]['column_mappings'])
+            child_tables.update(child_tables[child_name]['child_tables'])
+            force_types.extend(child_tables[child_name]['force_types'])
+            primary_keys.extend(child_tables[child_name]['primary_keys'])
 
-        return columns, child_tables, primary_keys, force_types
-
-    def _get_table_mapping_of_dict_node(self, node_thing):
-        dict_node_name = node_thing.get("node").data_name
-        primary_keys = []
-        force_types = []
-        columns = {}
-        child_tables = {}
-        for child in node_thing.get("children"):
-            child_columns, child_child_tables, child_primary_keys, child_force_types = self._analyze_child_node_mapping(
-                node_thing, child)
-            columns.update(child_columns)
-            child_tables.update(child_child_tables)
-            force_types.extend(child_force_types)
-            primary_keys.extend(child_primary_keys)
-
-        primary_keys = self.add_prefix_to_list_items(primary_keys, dict_node_name + ".")
-        force_types = self.add_prefix_to_list_items(force_types, dict_node_name + ".")
-        columns = self.add_prefix_to_dict_keys(columns, dict_node_name + ".")
-        child_tables = self.add_prefix_to_dict_keys(child_tables, dict_node_name + ".")
         return columns, child_tables, primary_keys, force_types
 
     def get_column_mappings_at_path(self, node_path: List[str]) -> Dict[str, str]:

--- a/src/keboola/json_to_csv/mapping.py
+++ b/src/keboola/json_to_csv/mapping.py
@@ -112,3 +112,16 @@ class TableMapping:
                    child_tables=child_tables,
                    force_types=mapping.get("force_types"),
                    user_data=mapping.get("user_data", {}))
+
+    def to_dict(self, parent_name=None) -> Dict:
+        current_table_name = f"{parent_name}_{self.table_name}" if parent_name else self.table_name
+        items = {current_table_name: {
+            'table_name': self.table_name,
+            'column_mappings': self.column_mappings,
+            'primary_keys': self.primary_keys,
+            'force_types': self.force_types,
+            'user_data': self.user_data
+        }}
+        for k, v in self.child_tables.items():
+            items.update(v.to_dict(parent_name=current_table_name))
+        return items

--- a/src/keboola/json_to_csv/mapping.py
+++ b/src/keboola/json_to_csv/mapping.py
@@ -66,11 +66,13 @@ class TableMapping:
         return full_mapping
 
     def as_dict(self):
-        return {"table_name": self.table_name,
-                "column_mappings": self.column_mappings,
-                "primary_keys": self.primary_keys,
-                "force_types": self.force_types,
-                "child_tables": self.child_tables}
+        return {
+            "table_name": self.table_name,
+            "column_mappings": self.column_mappings,
+            "primary_keys": self.primary_keys,
+            "force_types": self.force_types,
+            "child_tables": {key: value.as_dict() for key, value in self.child_tables.items()}
+        }
 
     @classmethod
     def build_from_legacy_mapping(cls,

--- a/src/keboola/json_to_csv/mapping.py
+++ b/src/keboola/json_to_csv/mapping.py
@@ -33,6 +33,43 @@ class TableMapping:
         self.force_types = force_types
         self.user_data = user_data
 
+    def get_table_mappings_flattened(self, path: Optional[str] = None) -> Dict:
+        """
+        Retrieve a flattened representation of the mapping structure based on a specified object path.
+        Primarily meant for debugging purposes.
+
+        Parameters:
+        - path (Optional[str]): The object path for which the mapping should be retrieved.
+                                If None, the full flattened mapping is returned.
+
+        Returns:
+        - Dict: Flattened representation of the mapping structure.
+        """
+        full_mapping = self._flatten_mapping(self.as_dict())
+
+        if path:
+            return {k: v for k, v in full_mapping.items() if k.startswith(path)}
+
+        return full_mapping
+
+    def _flatten_mapping(self, mapping: 'TableMapping', current_path: str = "") -> Dict:
+        flat_mappings = {}
+        separator = '.'
+        table_name = mapping.table_name
+        flat_mappings[table_name] = mapping  # Shallow copy of the mapping
+
+        for _, child_mapping in mapping.child_tables:
+            flat_mappings.update(self._flatten_mapping(child_mapping))
+
+        return flat_mappings
+
+    def as_dict(self):
+        return {"table_name": self.table_name,
+                "column_mappings": self.column_mappings,
+                "primary_keys": self.primary_keys,
+                "force_types": self.force_types,
+                "child_tables": self.child_tables}
+
     @classmethod
     def build_from_legacy_mapping(cls,
                                   legacy_mapping: dict,

--- a/src/keboola/json_to_csv/mapping.py
+++ b/src/keboola/json_to_csv/mapping.py
@@ -112,16 +112,3 @@ class TableMapping:
                    child_tables=child_tables,
                    force_types=mapping.get("force_types"),
                    user_data=mapping.get("user_data", {}))
-
-    def to_dict(self, parent_name=None) -> Dict:
-        current_table_name = f"{parent_name}_{self.table_name}" if parent_name else self.table_name
-        items = {current_table_name: {
-            'table_name': self.table_name,
-            'column_mappings': self.column_mappings,
-            'primary_keys': self.primary_keys,
-            'force_types': self.force_types,
-            'user_data': self.user_data
-        }}
-        for k, v in self.child_tables.items():
-            items.update(v.to_dict(parent_name=current_table_name))
-        return items

--- a/src/keboola/json_to_csv/parser.py
+++ b/src/keboola/json_to_csv/parser.py
@@ -107,25 +107,6 @@ class Parser:
 
         return full_mapping
 
-    def analyze_data(self, input_data: List[Dict], node_path: Optional[List[str]] = None) -> Dict[str, Table]:
-        """
-        Analyze input data and return a dictionary of Table objects.
-
-        Parameters:
-            input_data (List[Dict]): The JSON data to analyze.
-            node_path (Optional[List[str]]): The path to the current node being analyzed (default: None).
-
-        Returns:
-            Dict[str, Table]: A dictionary containing Table objects representing the analyzed data.
-        """
-        if not node_path:
-            node_path = []
-        for row in input_data:
-            if is_scalar(row):
-                row = {"data": row}
-            self._parse_row(row, node_path)
-        return self.analyzer.get_mapping_dict_fom_structure()
-
     @staticmethod
     def _get_parseable_data_from_input_data(input_data: Union[Dict, List[Dict]],
                                             root_name: Optional[str]) -> List[Dict]:

--- a/src/keboola/json_to_csv/parser.py
+++ b/src/keboola/json_to_csv/parser.py
@@ -86,6 +86,21 @@ class Parser:
         """
         return self.analyzer.get_mapping_dict_fom_structure()
 
+    def get_table_mapping_as_dict(self) -> Dict:
+        """
+        Retrieves the table mapping structure used by the parser in a dictionary format.
+
+        This method provides a flattened representation of the table mapping. Each key
+        represents a table name (e.g., "user" or "user_addresses") and its corresponding
+        value holds the mapping details for that table. Child tables are prefixed based
+        on their parent table names.
+
+        Returns:
+            Dict[str, Dict]: A dictionary with table names as keys and associated mapping
+                             configurations as values.
+        """
+        return self.table_mapping.to_dict()
+
     def analyze_data(self, input_data: List[Dict], node_path: Optional[List[str]] = None) -> Dict[str, Table]:
         """
         Analyze input data and return a dictionary of Table objects.

--- a/src/keboola/json_to_csv/parser.py
+++ b/src/keboola/json_to_csv/parser.py
@@ -77,35 +77,16 @@ class Parser:
         self._parse_data(data_to_parse)
         return {key: self._csv_file_results[key].rows for key in self._csv_file_results}
 
-    def get_table_mapping(self) -> Dict:
+    def get_table_mapping(self) -> TableMapping:
         """
         Get the table mapping used by the parser.
 
         Returns:
-            Dict: The table mapping used by the parser.
+            TableMapping: The table mapping used by the parser.
         """
-        return self.analyzer.get_mapping_dict_fom_structure()
+        table_mapping_dict = self.analyzer.get_mapping_dict_fom_structure()
 
-    def get_mapping_by_object_path(self, path: Optional[str] = None, separator: str = ".") -> Dict:
-        """
-        Retrieve a flattened representation of the mapping structure based on a specified object path.
-        Primarily meant for debugging purposes.
-
-        Parameters:
-        - path (Optional[str]): The object path for which the mapping should be retrieved.
-                                If None, the full flattened mapping is returned.
-        - separator (str): The separator used to delimit table names in the flattened representation.
-                           Default is '.'.
-
-        Returns:
-        - Dict: Flattened representation of the mapping structure.
-        """
-        full_mapping = self._flatten_mapping(self.analyzer.get_mapping_dict_fom_structure(), separator)
-
-        if path:
-            return {k: v for k, v in full_mapping.items() if k.startswith(path)}
-
-        return full_mapping
+        return TableMapping.build_from_mapping_dict(table_mapping_dict)
 
     @staticmethod
     def _get_parseable_data_from_input_data(input_data: Union[Dict, List[Dict]],
@@ -325,14 +306,3 @@ class Parser:
                 current_table_primary_keys[name] = data_row.get(child_node)
 
         return current_table_primary_keys
-
-    def _flatten_mapping(self, mapping: Dict, separator: str, current_path: str = "") -> Dict:
-        flat_mappings = {}
-        table_name = mapping.get('table_name', "")
-        new_path = current_path + separator + table_name if current_path else table_name
-        flat_mappings[new_path] = dict(mapping)  # Shallow copy of the mapping
-
-        for _, child_mapping in mapping.get('child_tables', {}).items():
-            flat_mappings.update(self._flatten_mapping(child_mapping, separator, new_path))
-
-        return flat_mappings


### PR DESCRIPTION
```
table_mappings = parser.get_table_mapping_as_dict()
for table_name, table_mapping in table_mappings.items():
    print(f"Table name: {table_name}")
    print(table_mapping)
```
    
Returns:
  
Table name: user
`{'table_name': 'user', 'column_mappings': {'id': 'id', 'name': 'name', 'details.weight': 'user_weight', 'details.height': 'user_height', 'details.hair_color': 'user_hair_color'}, 'primary_keys': ['id'], 'force_types': [], 'user_data': {}}`
Table name: user_addresses
`{'table_name': 'addresses', 'column_mappings': {'user_id': 'user_id', 'index': 'index', 'street': 'street', 'country': 'country', 'city': 'city'}, 'primary_keys': ['user_id', 'index'], 'force_types': [], 'user_data': {}}`

@davidesner Is this how you wanted it? I think it would be more handly if this would return the column_mappings key with only a list of target column names. If this is meant to be used just to hand over column names and pkeys for output mapping, I do not think we need original column names, do we? 
   