### PR TITLE
fix: use == instead of in for NodeType enum comparison in _perform_node_type_upgrade

### DIFF
--- a/docs/analyzer.html
+++ b/docs/analyzer.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.analyzer API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,477 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.analyzer</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">import copy
-from typing import Any, Dict, List, Optional, Union, Tuple
-
-from .exceptions import JsonParserException
-from .mapping import TableMapping
-from .node import Node, NodeType
-from .utils import is_dict, is_list, is_scalar
-
-
-class Analyzer:
-    &#34;&#34;&#34;
-    The Analyzer class is designed to analyze a data structure and build a node hierarchy
-    that represents the structure and data types of the objects within it. It can be used
-    to create mappings for tabular data and handle complex nested structures.
-
-    The Analyzer works based on a node hierarchy, where each node represents an object or
-    a field in the data structure. The hierarchy is built by analyzing the provided data
-    using the `analyze_object` method, or by having it be initialized by a predefined table
-    mapping by the user.
-
-    The Analyzer supports different data types, such as dictionaries, lists, scalars, and
-    nested structures. It can handle various scenarios, including lists of dictionaries,
-    lists of scalars, and more. The data types are represented using the `NodeType` enum.
-
-    To use the Analyzer, you can initialize an instance with an optional root name and
-    TableMapping. The TableMapping helps to specify the mapping of the data structure to
-    tabular data. Then, call the `analyze_object` method to analyze each object within
-    the data structure. The `get_mapping_dict_fom_structure` method can be used to get
-    the resulting mapping dictionary.
-
-    The class also provides methods to upgrade node data types and get column mappings at
-    specific paths in the hierarchy.
-
-    &#34;&#34;&#34;
-
-    def __init__(self,
-                 table_mapping: Optional[TableMapping] = None,
-                 root_name: Optional[str] = None) -&gt; None:
-        &#34;&#34;&#34;
-        Initialize the Analyzer object.
-
-        Args:
-            table_mapping (Optional[TableMapping]): The TableMapping object to use for the initialization of the
-                                                    node_hierarchy
-            root_name (Optional[str]): The root name for the data structure (optional).
-        &#34;&#34;&#34;
-
-        self.root_name = root_name
-        self.node_hierarchy = {&#34;children&#34;: {}, &#34;node&#34;: Node([], root_name, NodeType.LIST)}
-
-        if table_mapping:
-            self.update_with_table_mapping(table_mapping, None)
-
-    def get_mapping_dict_fom_structure(self) -&gt; Dict:
-        return self._get_table_mapping_of_node_hierarchy()
-
-    def analyze_object(self, path_to_object: List[Union[Any, str]], name: str, value: Any) -&gt; None:
-        &#34;&#34;&#34;
-            Analyzes an object within the data structure and updates the node hierarchy accordingly.
-
-            This method is a recursive function that analyzes each object and its nested objects
-            within the data structure. It updates the node hierarchy with the appropriate data types
-            and mappings for each object.
-
-            Args:
-                path_to_object (List[Union[Any, str]]): The path to the current object within the data structure.
-                    This list represents the sequence of keys or indices to reach the current object from the root.
-                name (str): The name of the current object. In the case of dictionaries, it represents the key name.
-                    In the case of lists, it represents the index.
-                value (Any): The value of the current object. It can be a scalar, dictionary, list, or None..
-            &#34;&#34;&#34;
-
-        object_path = self.create_path_to_child_object(path_to_object, name)
-
-        expected_node = self.get_node_dict(object_path)
-        if not expected_node:
-            real_type = self.get_value_type(path_to_object, value)
-            real_node = self.add_node(object_path, real_type)
-        else:
-            real_type = self.get_value_type(path_to_object, value)
-            expected_type = expected_node.get(&#34;node&#34;).data_type
-            if real_type != expected_type and not expected_node.get(&#34;node&#34;).force_type:
-                if self._check_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type):
-                    self._perform_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type)
-            real_node = self.get_node_dict(object_path)
-
-        if real_node[&#34;node&#34;].data_type == NodeType.DICT:
-            for sub_obj_name, sub_obj_value in value.items():
-                self.analyze_object(object_path, sub_obj_name, sub_obj_value)
-
-    def get_value_type(self, path_to_object: List[Union[Any, str]],
-                       value: Any) -&gt; NodeType:
-        &#34;&#34;&#34;
-           Get the data type of the given value within the data structure.
-
-           This method determines the NodeType of the provided value based on its data characteristics.
-           It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
-           it further analyzes the elements to determine if it&#39;s a list of scalars or a list of dictionaries.
-
-           Args:
-               path_to_object (List[Union[Any, str]]): The path to the current object within the data structure.
-                   This list represents the sequence of keys or indices to reach the current object from the root.
-               value (Any): The value to determine the data type for.
-           &#34;&#34;&#34;
-        if is_scalar(value):
-            node_type = NodeType.SCALAR
-        elif is_dict(value):
-            node_type = NodeType.DICT
-        elif value is None:
-            node_type = NodeType.NULL
-        elif is_list(value) and len(value) &gt; 0:
-            final_element_type = self.get_value_type_of_array_elements(path_to_object, value)
-            if final_element_type == NodeType.DICT:
-                node_type = NodeType.LIST_OF_DICTS
-            elif final_element_type == NodeType.SCALAR:
-                node_type = NodeType.LIST_OF_SCALARS
-            else:
-                node_type = NodeType.LIST
-        elif is_list(value):
-            node_type = NodeType.LIST
-        else:
-            raise JsonParserException(f&#34;Unsupported data in path {path_to_object}&#34;)
-        return node_type
-
-    def get_value_type_of_array_elements(self, path_to_object: List[Any], element_list: List[Any]) -&gt; NodeType:
-        &#34;&#34;&#34;
-        Get the common data type of elements within a list in the data structure.
-
-        This method determines the common NodeType of elements in the provided list. It iterates
-        through the elements and calls the `get_value_type` method to determine the data type of
-        each element. If all elements have the same data type, it returns that data type; otherwise,
-        it raises a JsonParserException indicating that the list has inconsistent element data types.
-
-        Args:
-            path_to_object (List[Any]): The path to the current object within the data structure.
-                This list represents the sequence of keys or indices to reach the current object from the root.
-            element_list (List[Any]): The list containing elements to analyze.
-
-        Returns:
-            NodeType: The common data type of elements within the list.
-        &#34;&#34;&#34;
-        final_element_type = NodeType.NULL
-        for element in element_list:
-            element_type = self.get_value_type(path_to_object, element)
-            if element_type != final_element_type:
-                if final_element_type == NodeType.NULL or element_type == NodeType.NULL:
-                    final_element_type = final_element_type if final_element_type != NodeType.NULL else element_type
-                else:
-                    raise JsonParserException(f&#34;Value types of list {path_to_object} &#34;
-                                              f&#34;are inconsistent : {element_list}&#34;)
-        return final_element_type
-
-    def _perform_node_type_upgrade(self, node, expected_type, real_type):
-        &#34;&#34;&#34;
-        Upgrade the data type of a node in the node hierarchy.
-
-        This method upgrades the data type of the provided node to the expected data type based
-        on the comparison of the current data type (`real_type`) and the expected data type
-        (`expected_type`). The method checks for specific scenarios where upgrading the data type
-        is possible, such as converting a NodeType.LIST to NodeType.LIST_OF_SCALARS or
-        NodeType.LIST_OF_DICTS.
-
-        Args:
-            node: The node object to upgrade in the node hierarchy.
-            expected_type (NodeType): The expected data type of the node.
-            real_type (NodeType): The current data type of the node.
-        &#34;&#34;&#34;
-        if expected_type == NodeType.NULL:
-            self.upgrade_node_type(node, real_type)
-        elif expected_type == NodeType.LIST and real_type == NodeType.LIST_OF_SCALARS:
-            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
-        elif expected_type == NodeType.LIST and real_type == NodeType.LIST_OF_DICTS:
-            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.LIST and real_type == NodeType.SCALAR:
-            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
-        elif expected_type == NodeType.LIST and real_type == NodeType.DICT:
-            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.DICT and real_type == NodeType.LIST_OF_DICTS:
-            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.DICT and real_type in NodeType.LIST:
-            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST_OF_SCALARS:
-            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
-        elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST:
-            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
-
-    @staticmethod
-    def _check_node_type_upgrade(node, expected_type, real_type):
-        &#34;&#34;&#34;
-        Check if upgrading the data type of a node is compatible.
-
-        This method checks whether upgrading the data type of the provided node to the expected
-        data type is a compatible operation. It analyzes the current data type (`real_type`) and
-        the expected data type (`expected_type`) and determines if the upgrade scenario is supported.
-
-        Args:
-            node: The node object to check for data type upgrade compatibility.
-            expected_type (NodeType): The expected data type of the node.
-            real_type (NodeType): The current data type of the node.
-
-        Returns:
-            bool: True if the data type upgrade is compatible; otherwise, raises a JsonParserException.
-
-        &#34;&#34;&#34;
-        varying_node_types = [expected_type, real_type]
-
-        one_type_is_dict = NodeType.DICT in varying_node_types
-        one_type_is_scalar = NodeType.SCALAR in varying_node_types
-        one_type_is_list_of_scalars = NodeType.LIST_OF_SCALARS in varying_node_types
-        one_type_is_list_of_dicts = NodeType.LIST_OF_DICTS in varying_node_types
-
-        if one_type_is_dict and one_type_is_scalar:
-            is_compatible = False
-        elif one_type_is_dict and one_type_is_list_of_scalars:
-            is_compatible = False
-        elif one_type_is_scalar and one_type_is_list_of_dicts:
-            is_compatible = False
-        elif one_type_is_list_of_scalars and one_type_is_list_of_dicts:
-            is_compatible = False
-        else:
-            is_compatible = True
-
-        if not is_compatible:
-            raise JsonParserException(f&#34;Incompatible types of {expected_type} and {real_type} &#34;
-                                      f&#34;in node_path {node.path}&#34;)
-        return True
-
-    def update_with_table_mapping(self, table_mapping: TableMapping, parent_path: Optional[List] = None) -&gt; None:
-        if not parent_path:
-            parent_path = []
-
-        self._process_column_mappings(table_mapping, parent_path)
-        self._process_user_data_mappings(table_mapping, parent_path)
-        self._process_child_table_mappings(table_mapping, parent_path)
-
-    def get_node_dict(self, path_to_object: List, parent_path: List = None) -&gt; Dict:
-        if parent_path:
-            path_to_object = parent_path + path_to_object
-        if len(path_to_object) &gt; 0:
-            node = self.node_hierarchy.get(&#34;children&#34;).get(path_to_object[0], {})
-        else:
-            node = self.node_hierarchy
-        if len(path_to_object) &gt; 1:
-            for path_step in path_to_object[1:]:
-                node = node.get(&#34;children&#34;).get(path_step, {})
-        return node or None
-
-    def add_node(self, path_to_object: List[str], value_type: NodeType, force_type: bool = False,
-                 destination_name: Optional[str] = None,
-                 is_primary_key: bool = False, default_value: Optional[str] = None) -&gt; Dict[str, Node]:
-        def recursive_add(node_dict, path, value_node):
-            if len(path) == 1:
-                node_dict[path[0]] = value_node
-            else:
-                first_level = path[0]
-                if first_level not in node_dict:
-                    node_dict[first_level] = {&#34;children&#34;: {}}
-                recursive_add(node_dict[first_level][&#34;children&#34;], path[1:], value_node)
-
-        parent_name = None
-        if len(path_to_object) &gt; 1:
-            parent_node = self.get_node_dict(path_to_object[:-1])
-            if parent_node.get(&#34;node&#34;).data_type == NodeType.DICT:
-                parent_name = parent_node.get(&#34;node&#34;).header_name
-
-        new_node = {&#34;node&#34;: Node(path_to_object, path_to_object[-1], value_type,
-                                 parent_name=parent_name, force_type=force_type, destination_name=destination_name,
-                                 is_primary_key=is_primary_key, default_value=default_value),
-                    &#34;children&#34;: {}}
-
-        # Start the recursive addition
-        recursive_add(self.node_hierarchy[&#34;children&#34;], path_to_object, new_node)
-
-        return new_node
-
-    def upgrade_node_type_recursive(self, hierarchy, path, new_node_type):
-        if len(path) == 1:
-            hierarchy[&#34;children&#34;][path[0]][&#34;node&#34;].data_type = new_node_type
-        else:
-            next_level = hierarchy[&#34;children&#34;][path[0]]
-            self.upgrade_node_type_recursive(next_level, path[1:], new_node_type)
-
-    def upgrade_node_type(self, node, new_node_type):
-        node_dict_to_update = self.get_node_dict(node.path)
-
-        node_dict_to_update[&#34;node&#34;].data_type = new_node_type
-
-        self.upgrade_node_type_recursive(self.node_hierarchy, node.path, new_node_type)
-
-    @staticmethod
-    def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; List[str]:
-        new_path = copy.copy(parent_path)
-        new_path.append(child_name)
-        return new_path
-
-    @staticmethod
-    def is_nested_node_name(node_name: str) -&gt; bool:
-        return &#34;.&#34; in node_name
-
-    def get_column_types(self, path: List[str]) -&gt; Dict[str, Tuple[NodeType, bool]]:
-        nodes = self.get_node_dict(path)
-        if not nodes:
-            return {}
-        headers = {}
-        for node in nodes.get(&#34;children&#34;):
-            decoded_name = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).data_name
-
-            data_type = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).data_type
-            force_type = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).force_type
-            headers[decoded_name] = (data_type, force_type)
-        return headers
-
-    def get_table_name(self, path: List[str]) -&gt; str:
-        name = self.root_name
-        for p in path:
-            name += f&#34;_{p}&#34;
-        return name
-
-    def _process_column_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
-        for column_name in table_mapping.column_mappings:
-            if self.is_nested_node_name(column_name):
-                self._process_nested_column_mapping(column_name, parent_path, table_mapping)
-            else:
-                self._process_column_mapping(column_name, parent_path, table_mapping)
-
-    def _process_column_mapping(self, column_name: str, parent_path: List[str],
-                                table_mapping: TableMapping) -&gt; None:
-        path = self.create_path_to_child_object(parent_path, column_name)
-
-        force_type = column_name in table_mapping.force_types
-        is_primary_key = column_name in table_mapping.primary_keys
-        destination_name = table_mapping.column_mappings.get(column_name)
-
-        self.add_node(path, NodeType.SCALAR, force_type=force_type, destination_name=destination_name,
-                      is_primary_key=is_primary_key)
-
-    def _process_nested_column_mapping(self, column_name: str, parent_path: List[Any],
-                                       table_mapping: TableMapping) -&gt; None:
-        split_name = column_name.split(&#34;.&#34;)
-        paths_added = []
-
-        for i, item in enumerate(split_name):
-            paths_added.append(item)
-            node = self.get_node_dict(paths_added, parent_path)
-            if not node:
-                path = parent_path.copy()
-                path.extend(paths_added)
-                force_type = column_name in table_mapping.force_types
-                is_primary_key = column_name in table_mapping.primary_keys
-                destination_name = table_mapping.column_mappings.get(column_name)
-
-                node_type = NodeType.DICT if i + 1 != len(split_name) else NodeType.SCALAR
-                self.add_node(path, node_type, force_type=force_type, destination_name=destination_name,
-                              is_primary_key=is_primary_key)
-
-    def _process_user_data_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
-        for user_data_name, default_value in table_mapping.user_data.items():
-            path = parent_path + [user_data_name]
-            self.add_node(path, NodeType.SCALAR, destination_name=user_data_name, default_value=default_value)
-
-    def _process_child_table_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
-        for child_table in table_mapping.child_tables:
-            path = parent_path.copy()
-            path.append(child_table)
-            self.add_node(path, NodeType.LIST)
-            self.update_with_table_mapping(table_mapping.child_tables.get(child_table), path)
-
-    def _get_table_mapping_of_node_hierarchy(self, node_hierarchy=None) -&gt; Dict:
-        if not node_hierarchy:
-            node_hierarchy = self.node_hierarchy
-        table_name = node_hierarchy.get(&#34;node&#34;).header_name
-
-        primary_keys = []
-        force_types = []
-        columns = {}
-        child_tables = {}
-        for child in node_hierarchy.get(&#34;children&#34;):
-            (child_columns, child_child_tables, child_primary_keys,
-             child_force_types) = self._analyze_child_node_mapping(node_hierarchy, child)
-            columns.update(child_columns)
-            child_tables.update(child_child_tables)
-            force_types.extend(child_force_types)
-            primary_keys.extend(child_primary_keys)
-        return {&#34;table_name&#34;: table_name,
-                &#34;column_mappings&#34;: columns,
-                &#34;primary_keys&#34;: primary_keys,
-                &#34;force_types&#34;: force_types,
-                &#34;child_tables&#34;: child_tables}
-
-    def _analyze_child_node_mapping(self, node_hierarchy, child_name):
-        primary_keys = []
-        force_types = []
-        columns = {}
-        child_tables = {}
-
-        child_node = node_hierarchy.get(&#34;children&#34;).get(child_name).get(&#34;node&#34;)
-        if child_node.data_type == NodeType.SCALAR:
-            columns[child_name] = child_node.header_name
-            if child_node.force_type:
-                force_types.append(child_name)
-            if child_node.is_primary_key:
-                primary_keys.append(child_name)
-
-        if child_node.data_type in [NodeType.LIST, NodeType.LIST_OF_SCALARS, NodeType.LIST_OF_DICTS]:
-            child_tables[child_name] = self._get_table_mapping_of_node_hierarchy(
-                node_hierarchy=node_hierarchy.get(&#34;children&#34;).get(child_name))
-
-        if child_node.data_type == NodeType.DICT:
-            (child_columns,
-             child_child_tables,
-             child_primary_keys,
-             child_force_types) = self._get_table_mapping_of_dict_node(node_hierarchy.get(&#34;children&#34;).get(child_name))
-            columns.update(child_columns)
-            child_tables.update(child_child_tables)
-            force_types.extend(child_force_types)
-            primary_keys.extend(child_primary_keys)
-
-        return columns, child_tables, primary_keys, force_types
-
-    def _get_table_mapping_of_dict_node(self, node_thing):
-        dict_node_name = node_thing.get(&#34;node&#34;).data_name
-        primary_keys = []
-        force_types = []
-        columns = {}
-        child_tables = {}
-        for child in node_thing.get(&#34;children&#34;):
-            (child_columns, child_child_tables,
-             child_primary_keys,
-             child_force_types) = self._analyze_child_node_mapping(node_thing, child)
-            columns.update(child_columns)
-            child_tables.update(child_child_tables)
-            force_types.extend(child_force_types)
-            primary_keys.extend(child_primary_keys)
-
-        primary_keys = self.add_prefix_to_list_items(primary_keys, dict_node_name + &#34;.&#34;)
-        force_types = self.add_prefix_to_list_items(force_types, dict_node_name + &#34;.&#34;)
-        columns = self.add_prefix_to_dict_keys(columns, dict_node_name + &#34;.&#34;)
-        child_tables = self.add_prefix_to_dict_keys(child_tables, dict_node_name + &#34;.&#34;)
-        return columns, child_tables, primary_keys, force_types
-
-    def get_column_mappings_at_path(self, node_path: List[str]) -&gt; Dict[str, str]:
-        headers = {}
-        node_data = self.get_node_dict(node_path) or {}
-        if &#34;node&#34; in node_data:
-            node_type = node_data.get(&#34;node&#34;).data_type
-            if node_type == NodeType.SCALAR:
-                headers[&#34;.&#34;.join(node_data.get(&#34;node&#34;).path)] = node_data.get(&#34;node&#34;).header_name
-
-        for node_name, data in node_data.get(&#34;children&#34;).items():
-            if data.get(&#34;node&#34;).data_type == NodeType.DICT:
-                ch = self.get_column_mappings_at_path(self.create_path_to_child_object(node_path, node_name))
-                headers.update(ch)
-            elif data.get(&#34;node&#34;).data_type == NodeType.LIST:
-                continue
-            else:
-                headers[&#34;.&#34;.join(data.get(&#34;node&#34;).path)] = data.get(&#34;node&#34;).header_name
-
-        return headers
-
-    @staticmethod
-    def add_prefix_to_list_items(input_list, prefix):
-        return [prefix + item for item in input_list]
-
-    @staticmethod
-    def add_prefix_to_dict_keys(input_dict, prefix):
-        return {prefix + key: value for key, value in input_dict.items()}</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -505,35 +48,9 @@ class Analyzer:
 <dl>
 <dt id="keboola.json_to_csv.analyzer.Analyzer"><code class="flex name class">
 <span>class <span class="ident">Analyzer</span></span>
-<span>(</span><span>table_mapping: Optional[<a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>] = None, root_name: Optional[str] = None)</span>
+<span>(</span><span>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a> | None = None,<br>root_name: str | None = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>The Analyzer class is designed to analyze a data structure and build a node hierarchy
-that represents the structure and data types of the objects within it. It can be used
-to create mappings for tabular data and handle complex nested structures.</p>
-<p>The Analyzer works based on a node hierarchy, where each node represents an object or
-a field in the data structure. The hierarchy is built by analyzing the provided data
-using the <code>analyze_object</code> method, or by having it be initialized by a predefined table
-mapping by the user.</p>
-<p>The Analyzer supports different data types, such as dictionaries, lists, scalars, and
-nested structures. It can handle various scenarios, including lists of dictionaries,
-lists of scalars, and more. The data types are represented using the <code>NodeType</code> enum.</p>
-<p>To use the Analyzer, you can initialize an instance with an optional root name and
-TableMapping. The TableMapping helps to specify the mapping of the data structure to
-tabular data. Then, call the <code>analyze_object</code> method to analyze each object within
-the data structure. The <code>get_mapping_dict_fom_structure</code> method can be used to get
-the resulting mapping dictionary.</p>
-<p>The class also provides methods to upgrade node data types and get column mappings at
-specific paths in the hierarchy.</p>
-<p>Initialize the Analyzer object.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>table_mapping</code></strong> :&ensp;<code>Optional[TableMapping]</code></dt>
-<dd>The TableMapping object to use for the initialization of the
-node_hierarchy</dd>
-<dt><strong><code>root_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
-<dd>The root name for the data structure (optional).</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -708,7 +225,7 @@ node_hierarchy</dd>
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.DICT and real_type == NodeType.LIST_OF_DICTS:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.DICT and real_type in NodeType.LIST:
+        elif expected_type == NodeType.DICT and real_type == NodeType.LIST:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST_OF_SCALARS:
             self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
@@ -996,13 +513,38 @@ node_hierarchy</dd>
     def add_prefix_to_dict_keys(input_dict, prefix):
         return {prefix + key: value for key, value in input_dict.items()}</code></pre>
 </details>
+<div class="desc"><p>The Analyzer class is designed to analyze a data structure and build a node hierarchy
+that represents the structure and data types of the objects within it. It can be used
+to create mappings for tabular data and handle complex nested structures.</p>
+<p>The Analyzer works based on a node hierarchy, where each node represents an object or
+a field in the data structure. The hierarchy is built by analyzing the provided data
+using the <code>analyze_object</code> method, or by having it be initialized by a predefined table
+mapping by the user.</p>
+<p>The Analyzer supports different data types, such as dictionaries, lists, scalars, and
+nested structures. It can handle various scenarios, including lists of dictionaries,
+lists of scalars, and more. The data types are represented using the <code>NodeType</code> enum.</p>
+<p>To use the Analyzer, you can initialize an instance with an optional root name and
+TableMapping. The TableMapping helps to specify the mapping of the data structure to
+tabular data. Then, call the <code>analyze_object</code> method to analyze each object within
+the data structure. The <code>get_mapping_dict_fom_structure</code> method can be used to get
+the resulting mapping dictionary.</p>
+<p>The class also provides methods to upgrade node data types and get column mappings at
+specific paths in the hierarchy.</p>
+<p>Initialize the Analyzer object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>table_mapping</code></strong> :&ensp;<code>Optional[TableMapping]</code></dt>
+<dd>The TableMapping object to use for the initialization of the
+node_hierarchy</dd>
+<dt><strong><code>root_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
+<dd>The root name for the data structure (optional).</dd>
+</dl></div>
 <h3>Static methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_prefix_to_dict_keys"><code class="name flex">
 <span>def <span class="ident">add_prefix_to_dict_keys</span></span>(<span>input_dict, prefix)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1011,12 +553,12 @@ node_hierarchy</dd>
 def add_prefix_to_dict_keys(input_dict, prefix):
     return {prefix + key: value for key, value in input_dict.items()}</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_prefix_to_list_items"><code class="name flex">
 <span>def <span class="ident">add_prefix_to_list_items</span></span>(<span>input_list, prefix)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1025,12 +567,12 @@ def add_prefix_to_dict_keys(input_dict, prefix):
 def add_prefix_to_list_items(input_list, prefix):
     return [prefix + item for item in input_list]</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.create_path_to_child_object"><code class="name flex">
 <span>def <span class="ident">create_path_to_child_object</span></span>(<span>parent_path: List[str], child_name: str) ‑> List[str]</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1041,12 +583,12 @@ def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; L
     new_path.append(child_name)
     return new_path</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.is_nested_node_name"><code class="name flex">
 <span>def <span class="ident">is_nested_node_name</span></span>(<span>node_name: str) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1055,15 +597,15 @@ def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; L
 def is_nested_node_name(node_name: str) -&gt; bool:
     return &#34;.&#34; in node_name</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_node"><code class="name flex">
-<span>def <span class="ident">add_node</span></span>(<span>self, path_to_object: List[str], value_type: <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>, force_type: bool = False, destination_name: Optional[str] = None, is_primary_key: bool = False, default_value: Optional[str] = None) ‑> Dict[str, <a title="keboola.json_to_csv.node.Node" href="node.html#keboola.json_to_csv.node.Node">Node</a>]</span>
+<span>def <span class="ident">add_node</span></span>(<span>self,<br>path_to_object: List[str],<br>value_type: <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>,<br>force_type: bool = False,<br>destination_name: str | None = None,<br>is_primary_key: bool = False,<br>default_value: str | None = None) ‑> Dict[str, <a title="keboola.json_to_csv.node.Node" href="node.html#keboola.json_to_csv.node.Node">Node</a>]</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1096,26 +638,12 @@ def is_nested_node_name(node_name: str) -&gt; bool:
 
     return new_node</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.analyze_object"><code class="name flex">
-<span>def <span class="ident">analyze_object</span></span>(<span>self, path_to_object: List[Union[Any, str]], name: str, value: Any) ‑> None</span>
+<span>def <span class="ident">analyze_object</span></span>(<span>self, path_to_object: List[Any | str], name: str, value: Any) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Analyzes an object within the data structure and updates the node hierarchy accordingly.</p>
-<p>This method is a recursive function that analyzes each object and its nested objects
-within the data structure. It updates the node hierarchy with the appropriate data types
-and mappings for each object.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the current object. In the case of dictionaries, it represents the key name.
-In the case of lists, it represents the index.</dd>
-<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
-<dd>The value of the current object. It can be a scalar, dictionary, list, or None..</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1154,12 +682,26 @@ In the case of lists, it represents the index.</dd>
         for sub_obj_name, sub_obj_value in value.items():
             self.analyze_object(object_path, sub_obj_name, sub_obj_value)</code></pre>
 </details>
+<div class="desc"><p>Analyzes an object within the data structure and updates the node hierarchy accordingly.</p>
+<p>This method is a recursive function that analyzes each object and its nested objects
+within the data structure. It updates the node hierarchy with the appropriate data types
+and mappings for each object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the current object. In the case of dictionaries, it represents the key name.
+In the case of lists, it represents the index.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
+<dd>The value of the current object. It can be a scalar, dictionary, list, or None..</dd>
+</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_column_mappings_at_path"><code class="name flex">
 <span>def <span class="ident">get_column_mappings_at_path</span></span>(<span>self, node_path: List[str]) ‑> Dict[str, str]</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1183,12 +725,12 @@ In the case of lists, it represents the index.</dd>
 
     return headers</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_column_types"><code class="name flex">
 <span>def <span class="ident">get_column_types</span></span>(<span>self, path: List[str]) ‑> Dict[str, Tuple[<a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>, bool]]</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1206,12 +748,12 @@ In the case of lists, it represents the index.</dd>
         headers[decoded_name] = (data_type, force_type)
     return headers</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_mapping_dict_fom_structure"><code class="name flex">
 <span>def <span class="ident">get_mapping_dict_fom_structure</span></span>(<span>self) ‑> Dict</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1219,12 +761,12 @@ In the case of lists, it represents the index.</dd>
 <pre><code class="python">def get_mapping_dict_fom_structure(self) -&gt; Dict:
     return self._get_table_mapping_of_node_hierarchy()</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_node_dict"><code class="name flex">
 <span>def <span class="ident">get_node_dict</span></span>(<span>self, path_to_object: List, parent_path: List = None) ‑> Dict</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1241,12 +783,12 @@ In the case of lists, it represents the index.</dd>
             node = node.get(&#34;children&#34;).get(path_step, {})
     return node or None</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_table_name"><code class="name flex">
 <span>def <span class="ident">get_table_name</span></span>(<span>self, path: List[str]) ‑> str</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1257,23 +799,12 @@ In the case of lists, it represents the index.</dd>
         name += f&#34;_{p}&#34;
     return name</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_value_type"><code class="name flex">
-<span>def <span class="ident">get_value_type</span></span>(<span>self, path_to_object: List[Union[Any, str]], value: Any) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
+<span>def <span class="ident">get_value_type</span></span>(<span>self, path_to_object: List[Any | str], value: Any) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
-<div class="desc"><p>Get the data type of the given value within the data structure.</p>
-<p>This method determines the NodeType of the provided value based on its data characteristics.
-It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
-it further analyzes the elements to determine if it's a list of scalars or a list of dictionaries.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
-<dd>The value to determine the data type for.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1312,29 +843,23 @@ This list represents the sequence of keys or indices to reach the current object
         raise JsonParserException(f&#34;Unsupported data in path {path_to_object}&#34;)
     return node_type</code></pre>
 </details>
+<div class="desc"><p>Get the data type of the given value within the data structure.</p>
+<p>This method determines the NodeType of the provided value based on its data characteristics.
+It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
+it further analyzes the elements to determine if it's a list of scalars or a list of dictionaries.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
+<dd>The value to determine the data type for.</dd>
+</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_value_type_of_array_elements"><code class="name flex">
 <span>def <span class="ident">get_value_type_of_array_elements</span></span>(<span>self, path_to_object: List[Any], element_list: List[Any]) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
-<div class="desc"><p>Get the common data type of elements within a list in the data structure.</p>
-<p>This method determines the common NodeType of elements in the provided list. It iterates
-through the elements and calls the <code>get_value_type</code> method to determine the data type of
-each element. If all elements have the same data type, it returns that data type; otherwise,
-it raises a JsonParserException indicating that the list has inconsistent element data types.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Any]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>element_list</code></strong> :&ensp;<code>List[Any]</code></dt>
-<dd>The list containing elements to analyze.</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>NodeType</code></dt>
-<dd>The common data type of elements within the list.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1367,12 +892,29 @@ This list represents the sequence of keys or indices to reach the current object
                                           f&#34;are inconsistent : {element_list}&#34;)
     return final_element_type</code></pre>
 </details>
+<div class="desc"><p>Get the common data type of elements within a list in the data structure.</p>
+<p>This method determines the common NodeType of elements in the provided list. It iterates
+through the elements and calls the <code>get_value_type</code> method to determine the data type of
+each element. If all elements have the same data type, it returns that data type; otherwise,
+it raises a JsonParserException indicating that the list has inconsistent element data types.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Any]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>element_list</code></strong> :&ensp;<code>List[Any]</code></dt>
+<dd>The list containing elements to analyze.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>NodeType</code></dt>
+<dd>The common data type of elements within the list.</dd>
+</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.update_with_table_mapping"><code class="name flex">
-<span>def <span class="ident">update_with_table_mapping</span></span>(<span>self, table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>, parent_path: Optional[List] = None) ‑> None</span>
+<span>def <span class="ident">update_with_table_mapping</span></span>(<span>self,<br>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>,<br>parent_path: List | None = None) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1385,12 +927,12 @@ This list represents the sequence of keys or indices to reach the current object
     self._process_user_data_mappings(table_mapping, parent_path)
     self._process_child_table_mappings(table_mapping, parent_path)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.upgrade_node_type"><code class="name flex">
 <span>def <span class="ident">upgrade_node_type</span></span>(<span>self, node, new_node_type)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1402,12 +944,12 @@ This list represents the sequence of keys or indices to reach the current object
 
     self.upgrade_node_type_recursive(self.node_hierarchy, node.path, new_node_type)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.upgrade_node_type_recursive"><code class="name flex">
 <span>def <span class="ident">upgrade_node_type_recursive</span></span>(<span>self, hierarchy, path, new_node_type)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1419,6 +961,7 @@ This list represents the sequence of keys or indices to reach the current object
         next_level = hierarchy[&#34;children&#34;][path[0]]
         self.upgrade_node_type_recursive(next_level, path[1:], new_node_type)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 </dl>
 </dd>
@@ -1426,7 +969,6 @@ This list represents the sequence of keys or indices to reach the current object
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -1465,7 +1007,7 @@ This list represents the sequence of keys or indices to reach the current object
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/analyzer.html
+++ b/docs/analyzer.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.analyzer API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,26 +22,20 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.analyzer</code></h1>
 </header>
 <section id="section-intro">
-</section>
-<section>
-</section>
-<section>
-</section>
-<section>
-</section>
-<section>
-<h2 class="section-title" id="header-classes">Classes</h2>
-<dl>
-<dt id="keboola.json_to_csv.analyzer.Analyzer"><code class="flex name class">
-<span>class <span class="ident">Analyzer</span></span>
-<span>(</span><span>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a> | None = None,<br>root_name: str | None = None)</span>
-</code></dt>
-<dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class Analyzer:
+<pre><code class="python">import copy
+from typing import Any, Dict, List, Optional, Union, Tuple
+
+from .exceptions import JsonParserException
+from .mapping import TableMapping
+from .node import Node, NodeType
+from .utils import is_dict, is_list, is_scalar
+
+
+class Analyzer:
     &#34;&#34;&#34;
     The Analyzer class is designed to analyze a data structure and build a node hierarchy
     that represents the structure and data types of the objects within it. It can be used
@@ -225,7 +205,7 @@ el.replaceWith(d);
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.DICT and real_type == NodeType.LIST_OF_DICTS:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.DICT and real_type == NodeType.LIST:
+        elif expected_type == NodeType.DICT and real_type in NodeType.LIST:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST_OF_SCALARS:
             self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
@@ -513,6 +493,21 @@ el.replaceWith(d);
     def add_prefix_to_dict_keys(input_dict, prefix):
         return {prefix + key: value for key, value in input_dict.items()}</code></pre>
 </details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="keboola.json_to_csv.analyzer.Analyzer"><code class="flex name class">
+<span>class <span class="ident">Analyzer</span></span>
+<span>(</span><span>table_mapping: Optional[<a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>] = None, root_name: Optional[str] = None)</span>
+</code></dt>
+<dd>
 <div class="desc"><p>The Analyzer class is designed to analyze a data structure and build a node hierarchy
 that represents the structure and data types of the objects within it. It can be used
 to create mappings for tabular data and handle complex nested structures.</p>
@@ -539,12 +534,475 @@ node_hierarchy</dd>
 <dt><strong><code>root_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
 <dd>The root name for the data structure (optional).</dd>
 </dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Analyzer:
+    &#34;&#34;&#34;
+    The Analyzer class is designed to analyze a data structure and build a node hierarchy
+    that represents the structure and data types of the objects within it. It can be used
+    to create mappings for tabular data and handle complex nested structures.
+
+    The Analyzer works based on a node hierarchy, where each node represents an object or
+    a field in the data structure. The hierarchy is built by analyzing the provided data
+    using the `analyze_object` method, or by having it be initialized by a predefined table
+    mapping by the user.
+
+    The Analyzer supports different data types, such as dictionaries, lists, scalars, and
+    nested structures. It can handle various scenarios, including lists of dictionaries,
+    lists of scalars, and more. The data types are represented using the `NodeType` enum.
+
+    To use the Analyzer, you can initialize an instance with an optional root name and
+    TableMapping. The TableMapping helps to specify the mapping of the data structure to
+    tabular data. Then, call the `analyze_object` method to analyze each object within
+    the data structure. The `get_mapping_dict_fom_structure` method can be used to get
+    the resulting mapping dictionary.
+
+    The class also provides methods to upgrade node data types and get column mappings at
+    specific paths in the hierarchy.
+
+    &#34;&#34;&#34;
+
+    def __init__(self,
+                 table_mapping: Optional[TableMapping] = None,
+                 root_name: Optional[str] = None) -&gt; None:
+        &#34;&#34;&#34;
+        Initialize the Analyzer object.
+
+        Args:
+            table_mapping (Optional[TableMapping]): The TableMapping object to use for the initialization of the
+                                                    node_hierarchy
+            root_name (Optional[str]): The root name for the data structure (optional).
+        &#34;&#34;&#34;
+
+        self.root_name = root_name
+        self.node_hierarchy = {&#34;children&#34;: {}, &#34;node&#34;: Node([], root_name, NodeType.LIST)}
+
+        if table_mapping:
+            self.update_with_table_mapping(table_mapping, None)
+
+    def get_mapping_dict_fom_structure(self) -&gt; Dict:
+        return self._get_table_mapping_of_node_hierarchy()
+
+    def analyze_object(self, path_to_object: List[Union[Any, str]], name: str, value: Any) -&gt; None:
+        &#34;&#34;&#34;
+            Analyzes an object within the data structure and updates the node hierarchy accordingly.
+
+            This method is a recursive function that analyzes each object and its nested objects
+            within the data structure. It updates the node hierarchy with the appropriate data types
+            and mappings for each object.
+
+            Args:
+                path_to_object (List[Union[Any, str]]): The path to the current object within the data structure.
+                    This list represents the sequence of keys or indices to reach the current object from the root.
+                name (str): The name of the current object. In the case of dictionaries, it represents the key name.
+                    In the case of lists, it represents the index.
+                value (Any): The value of the current object. It can be a scalar, dictionary, list, or None..
+            &#34;&#34;&#34;
+
+        object_path = self.create_path_to_child_object(path_to_object, name)
+
+        expected_node = self.get_node_dict(object_path)
+        if not expected_node:
+            real_type = self.get_value_type(path_to_object, value)
+            real_node = self.add_node(object_path, real_type)
+        else:
+            real_type = self.get_value_type(path_to_object, value)
+            expected_type = expected_node.get(&#34;node&#34;).data_type
+            if real_type != expected_type and not expected_node.get(&#34;node&#34;).force_type:
+                if self._check_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type):
+                    self._perform_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type)
+            real_node = self.get_node_dict(object_path)
+
+        if real_node[&#34;node&#34;].data_type == NodeType.DICT:
+            for sub_obj_name, sub_obj_value in value.items():
+                self.analyze_object(object_path, sub_obj_name, sub_obj_value)
+
+    def get_value_type(self, path_to_object: List[Union[Any, str]],
+                       value: Any) -&gt; NodeType:
+        &#34;&#34;&#34;
+           Get the data type of the given value within the data structure.
+
+           This method determines the NodeType of the provided value based on its data characteristics.
+           It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
+           it further analyzes the elements to determine if it&#39;s a list of scalars or a list of dictionaries.
+
+           Args:
+               path_to_object (List[Union[Any, str]]): The path to the current object within the data structure.
+                   This list represents the sequence of keys or indices to reach the current object from the root.
+               value (Any): The value to determine the data type for.
+           &#34;&#34;&#34;
+        if is_scalar(value):
+            node_type = NodeType.SCALAR
+        elif is_dict(value):
+            node_type = NodeType.DICT
+        elif value is None:
+            node_type = NodeType.NULL
+        elif is_list(value) and len(value) &gt; 0:
+            final_element_type = self.get_value_type_of_array_elements(path_to_object, value)
+            if final_element_type == NodeType.DICT:
+                node_type = NodeType.LIST_OF_DICTS
+            elif final_element_type == NodeType.SCALAR:
+                node_type = NodeType.LIST_OF_SCALARS
+            else:
+                node_type = NodeType.LIST
+        elif is_list(value):
+            node_type = NodeType.LIST
+        else:
+            raise JsonParserException(f&#34;Unsupported data in path {path_to_object}&#34;)
+        return node_type
+
+    def get_value_type_of_array_elements(self, path_to_object: List[Any], element_list: List[Any]) -&gt; NodeType:
+        &#34;&#34;&#34;
+        Get the common data type of elements within a list in the data structure.
+
+        This method determines the common NodeType of elements in the provided list. It iterates
+        through the elements and calls the `get_value_type` method to determine the data type of
+        each element. If all elements have the same data type, it returns that data type; otherwise,
+        it raises a JsonParserException indicating that the list has inconsistent element data types.
+
+        Args:
+            path_to_object (List[Any]): The path to the current object within the data structure.
+                This list represents the sequence of keys or indices to reach the current object from the root.
+            element_list (List[Any]): The list containing elements to analyze.
+
+        Returns:
+            NodeType: The common data type of elements within the list.
+        &#34;&#34;&#34;
+        final_element_type = NodeType.NULL
+        for element in element_list:
+            element_type = self.get_value_type(path_to_object, element)
+            if element_type != final_element_type:
+                if final_element_type == NodeType.NULL or element_type == NodeType.NULL:
+                    final_element_type = final_element_type if final_element_type != NodeType.NULL else element_type
+                else:
+                    raise JsonParserException(f&#34;Value types of list {path_to_object} &#34;
+                                              f&#34;are inconsistent : {element_list}&#34;)
+        return final_element_type
+
+    def _perform_node_type_upgrade(self, node, expected_type, real_type):
+        &#34;&#34;&#34;
+        Upgrade the data type of a node in the node hierarchy.
+
+        This method upgrades the data type of the provided node to the expected data type based
+        on the comparison of the current data type (`real_type`) and the expected data type
+        (`expected_type`). The method checks for specific scenarios where upgrading the data type
+        is possible, such as converting a NodeType.LIST to NodeType.LIST_OF_SCALARS or
+        NodeType.LIST_OF_DICTS.
+
+        Args:
+            node: The node object to upgrade in the node hierarchy.
+            expected_type (NodeType): The expected data type of the node.
+            real_type (NodeType): The current data type of the node.
+        &#34;&#34;&#34;
+        if expected_type == NodeType.NULL:
+            self.upgrade_node_type(node, real_type)
+        elif expected_type == NodeType.LIST and real_type == NodeType.LIST_OF_SCALARS:
+            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
+        elif expected_type == NodeType.LIST and real_type == NodeType.LIST_OF_DICTS:
+            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
+        elif expected_type == NodeType.LIST and real_type == NodeType.SCALAR:
+            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
+        elif expected_type == NodeType.LIST and real_type == NodeType.DICT:
+            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
+        elif expected_type == NodeType.DICT and real_type == NodeType.LIST_OF_DICTS:
+            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
+        elif expected_type == NodeType.DICT and real_type in NodeType.LIST:
+            self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
+        elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST_OF_SCALARS:
+            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
+        elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST:
+            self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)
+
+    @staticmethod
+    def _check_node_type_upgrade(node, expected_type, real_type):
+        &#34;&#34;&#34;
+        Check if upgrading the data type of a node is compatible.
+
+        This method checks whether upgrading the data type of the provided node to the expected
+        data type is a compatible operation. It analyzes the current data type (`real_type`) and
+        the expected data type (`expected_type`) and determines if the upgrade scenario is supported.
+
+        Args:
+            node: The node object to check for data type upgrade compatibility.
+            expected_type (NodeType): The expected data type of the node.
+            real_type (NodeType): The current data type of the node.
+
+        Returns:
+            bool: True if the data type upgrade is compatible; otherwise, raises a JsonParserException.
+
+        &#34;&#34;&#34;
+        varying_node_types = [expected_type, real_type]
+
+        one_type_is_dict = NodeType.DICT in varying_node_types
+        one_type_is_scalar = NodeType.SCALAR in varying_node_types
+        one_type_is_list_of_scalars = NodeType.LIST_OF_SCALARS in varying_node_types
+        one_type_is_list_of_dicts = NodeType.LIST_OF_DICTS in varying_node_types
+
+        if one_type_is_dict and one_type_is_scalar:
+            is_compatible = False
+        elif one_type_is_dict and one_type_is_list_of_scalars:
+            is_compatible = False
+        elif one_type_is_scalar and one_type_is_list_of_dicts:
+            is_compatible = False
+        elif one_type_is_list_of_scalars and one_type_is_list_of_dicts:
+            is_compatible = False
+        else:
+            is_compatible = True
+
+        if not is_compatible:
+            raise JsonParserException(f&#34;Incompatible types of {expected_type} and {real_type} &#34;
+                                      f&#34;in node_path {node.path}&#34;)
+        return True
+
+    def update_with_table_mapping(self, table_mapping: TableMapping, parent_path: Optional[List] = None) -&gt; None:
+        if not parent_path:
+            parent_path = []
+
+        self._process_column_mappings(table_mapping, parent_path)
+        self._process_user_data_mappings(table_mapping, parent_path)
+        self._process_child_table_mappings(table_mapping, parent_path)
+
+    def get_node_dict(self, path_to_object: List, parent_path: List = None) -&gt; Dict:
+        if parent_path:
+            path_to_object = parent_path + path_to_object
+        if len(path_to_object) &gt; 0:
+            node = self.node_hierarchy.get(&#34;children&#34;).get(path_to_object[0], {})
+        else:
+            node = self.node_hierarchy
+        if len(path_to_object) &gt; 1:
+            for path_step in path_to_object[1:]:
+                node = node.get(&#34;children&#34;).get(path_step, {})
+        return node or None
+
+    def add_node(self, path_to_object: List[str], value_type: NodeType, force_type: bool = False,
+                 destination_name: Optional[str] = None,
+                 is_primary_key: bool = False, default_value: Optional[str] = None) -&gt; Dict[str, Node]:
+        def recursive_add(node_dict, path, value_node):
+            if len(path) == 1:
+                node_dict[path[0]] = value_node
+            else:
+                first_level = path[0]
+                if first_level not in node_dict:
+                    node_dict[first_level] = {&#34;children&#34;: {}}
+                recursive_add(node_dict[first_level][&#34;children&#34;], path[1:], value_node)
+
+        parent_name = None
+        if len(path_to_object) &gt; 1:
+            parent_node = self.get_node_dict(path_to_object[:-1])
+            if parent_node.get(&#34;node&#34;).data_type == NodeType.DICT:
+                parent_name = parent_node.get(&#34;node&#34;).header_name
+
+        new_node = {&#34;node&#34;: Node(path_to_object, path_to_object[-1], value_type,
+                                 parent_name=parent_name, force_type=force_type, destination_name=destination_name,
+                                 is_primary_key=is_primary_key, default_value=default_value),
+                    &#34;children&#34;: {}}
+
+        # Start the recursive addition
+        recursive_add(self.node_hierarchy[&#34;children&#34;], path_to_object, new_node)
+
+        return new_node
+
+    def upgrade_node_type_recursive(self, hierarchy, path, new_node_type):
+        if len(path) == 1:
+            hierarchy[&#34;children&#34;][path[0]][&#34;node&#34;].data_type = new_node_type
+        else:
+            next_level = hierarchy[&#34;children&#34;][path[0]]
+            self.upgrade_node_type_recursive(next_level, path[1:], new_node_type)
+
+    def upgrade_node_type(self, node, new_node_type):
+        node_dict_to_update = self.get_node_dict(node.path)
+
+        node_dict_to_update[&#34;node&#34;].data_type = new_node_type
+
+        self.upgrade_node_type_recursive(self.node_hierarchy, node.path, new_node_type)
+
+    @staticmethod
+    def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; List[str]:
+        new_path = copy.copy(parent_path)
+        new_path.append(child_name)
+        return new_path
+
+    @staticmethod
+    def is_nested_node_name(node_name: str) -&gt; bool:
+        return &#34;.&#34; in node_name
+
+    def get_column_types(self, path: List[str]) -&gt; Dict[str, Tuple[NodeType, bool]]:
+        nodes = self.get_node_dict(path)
+        if not nodes:
+            return {}
+        headers = {}
+        for node in nodes.get(&#34;children&#34;):
+            decoded_name = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).data_name
+
+            data_type = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).data_type
+            force_type = nodes.get(&#34;children&#34;)[node].get(&#34;node&#34;).force_type
+            headers[decoded_name] = (data_type, force_type)
+        return headers
+
+    def get_table_name(self, path: List[str]) -&gt; str:
+        name = self.root_name
+        for p in path:
+            name += f&#34;_{p}&#34;
+        return name
+
+    def _process_column_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
+        for column_name in table_mapping.column_mappings:
+            if self.is_nested_node_name(column_name):
+                self._process_nested_column_mapping(column_name, parent_path, table_mapping)
+            else:
+                self._process_column_mapping(column_name, parent_path, table_mapping)
+
+    def _process_column_mapping(self, column_name: str, parent_path: List[str],
+                                table_mapping: TableMapping) -&gt; None:
+        path = self.create_path_to_child_object(parent_path, column_name)
+
+        force_type = column_name in table_mapping.force_types
+        is_primary_key = column_name in table_mapping.primary_keys
+        destination_name = table_mapping.column_mappings.get(column_name)
+
+        self.add_node(path, NodeType.SCALAR, force_type=force_type, destination_name=destination_name,
+                      is_primary_key=is_primary_key)
+
+    def _process_nested_column_mapping(self, column_name: str, parent_path: List[Any],
+                                       table_mapping: TableMapping) -&gt; None:
+        split_name = column_name.split(&#34;.&#34;)
+        paths_added = []
+
+        for i, item in enumerate(split_name):
+            paths_added.append(item)
+            node = self.get_node_dict(paths_added, parent_path)
+            if not node:
+                path = parent_path.copy()
+                path.extend(paths_added)
+                force_type = column_name in table_mapping.force_types
+                is_primary_key = column_name in table_mapping.primary_keys
+                destination_name = table_mapping.column_mappings.get(column_name)
+
+                node_type = NodeType.DICT if i + 1 != len(split_name) else NodeType.SCALAR
+                self.add_node(path, node_type, force_type=force_type, destination_name=destination_name,
+                              is_primary_key=is_primary_key)
+
+    def _process_user_data_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
+        for user_data_name, default_value in table_mapping.user_data.items():
+            path = parent_path + [user_data_name]
+            self.add_node(path, NodeType.SCALAR, destination_name=user_data_name, default_value=default_value)
+
+    def _process_child_table_mappings(self, table_mapping: TableMapping, parent_path: List[str]) -&gt; None:
+        for child_table in table_mapping.child_tables:
+            path = parent_path.copy()
+            path.append(child_table)
+            self.add_node(path, NodeType.LIST)
+            self.update_with_table_mapping(table_mapping.child_tables.get(child_table), path)
+
+    def _get_table_mapping_of_node_hierarchy(self, node_hierarchy=None) -&gt; Dict:
+        if not node_hierarchy:
+            node_hierarchy = self.node_hierarchy
+        table_name = node_hierarchy.get(&#34;node&#34;).header_name
+
+        primary_keys = []
+        force_types = []
+        columns = {}
+        child_tables = {}
+        for child in node_hierarchy.get(&#34;children&#34;):
+            (child_columns, child_child_tables, child_primary_keys,
+             child_force_types) = self._analyze_child_node_mapping(node_hierarchy, child)
+            columns.update(child_columns)
+            child_tables.update(child_child_tables)
+            force_types.extend(child_force_types)
+            primary_keys.extend(child_primary_keys)
+        return {&#34;table_name&#34;: table_name,
+                &#34;column_mappings&#34;: columns,
+                &#34;primary_keys&#34;: primary_keys,
+                &#34;force_types&#34;: force_types,
+                &#34;child_tables&#34;: child_tables}
+
+    def _analyze_child_node_mapping(self, node_hierarchy, child_name):
+        primary_keys = []
+        force_types = []
+        columns = {}
+        child_tables = {}
+
+        child_node = node_hierarchy.get(&#34;children&#34;).get(child_name).get(&#34;node&#34;)
+        if child_node.data_type == NodeType.SCALAR:
+            columns[child_name] = child_node.header_name
+            if child_node.force_type:
+                force_types.append(child_name)
+            if child_node.is_primary_key:
+                primary_keys.append(child_name)
+
+        if child_node.data_type in [NodeType.LIST, NodeType.LIST_OF_SCALARS, NodeType.LIST_OF_DICTS]:
+            child_tables[child_name] = self._get_table_mapping_of_node_hierarchy(
+                node_hierarchy=node_hierarchy.get(&#34;children&#34;).get(child_name))
+
+        if child_node.data_type == NodeType.DICT:
+            (child_columns,
+             child_child_tables,
+             child_primary_keys,
+             child_force_types) = self._get_table_mapping_of_dict_node(node_hierarchy.get(&#34;children&#34;).get(child_name))
+            columns.update(child_columns)
+            child_tables.update(child_child_tables)
+            force_types.extend(child_force_types)
+            primary_keys.extend(child_primary_keys)
+
+        return columns, child_tables, primary_keys, force_types
+
+    def _get_table_mapping_of_dict_node(self, node_thing):
+        dict_node_name = node_thing.get(&#34;node&#34;).data_name
+        primary_keys = []
+        force_types = []
+        columns = {}
+        child_tables = {}
+        for child in node_thing.get(&#34;children&#34;):
+            (child_columns, child_child_tables,
+             child_primary_keys,
+             child_force_types) = self._analyze_child_node_mapping(node_thing, child)
+            columns.update(child_columns)
+            child_tables.update(child_child_tables)
+            force_types.extend(child_force_types)
+            primary_keys.extend(child_primary_keys)
+
+        primary_keys = self.add_prefix_to_list_items(primary_keys, dict_node_name + &#34;.&#34;)
+        force_types = self.add_prefix_to_list_items(force_types, dict_node_name + &#34;.&#34;)
+        columns = self.add_prefix_to_dict_keys(columns, dict_node_name + &#34;.&#34;)
+        child_tables = self.add_prefix_to_dict_keys(child_tables, dict_node_name + &#34;.&#34;)
+        return columns, child_tables, primary_keys, force_types
+
+    def get_column_mappings_at_path(self, node_path: List[str]) -&gt; Dict[str, str]:
+        headers = {}
+        node_data = self.get_node_dict(node_path) or {}
+        if &#34;node&#34; in node_data:
+            node_type = node_data.get(&#34;node&#34;).data_type
+            if node_type == NodeType.SCALAR:
+                headers[&#34;.&#34;.join(node_data.get(&#34;node&#34;).path)] = node_data.get(&#34;node&#34;).header_name
+
+        for node_name, data in node_data.get(&#34;children&#34;).items():
+            if data.get(&#34;node&#34;).data_type == NodeType.DICT:
+                ch = self.get_column_mappings_at_path(self.create_path_to_child_object(node_path, node_name))
+                headers.update(ch)
+            elif data.get(&#34;node&#34;).data_type == NodeType.LIST:
+                continue
+            else:
+                headers[&#34;.&#34;.join(data.get(&#34;node&#34;).path)] = data.get(&#34;node&#34;).header_name
+
+        return headers
+
+    @staticmethod
+    def add_prefix_to_list_items(input_list, prefix):
+        return [prefix + item for item in input_list]
+
+    @staticmethod
+    def add_prefix_to_dict_keys(input_dict, prefix):
+        return {prefix + key: value for key, value in input_dict.items()}</code></pre>
+</details>
 <h3>Static methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_prefix_to_dict_keys"><code class="name flex">
 <span>def <span class="ident">add_prefix_to_dict_keys</span></span>(<span>input_dict, prefix)</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -553,12 +1011,12 @@ node_hierarchy</dd>
 def add_prefix_to_dict_keys(input_dict, prefix):
     return {prefix + key: value for key, value in input_dict.items()}</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_prefix_to_list_items"><code class="name flex">
 <span>def <span class="ident">add_prefix_to_list_items</span></span>(<span>input_list, prefix)</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -567,12 +1025,12 @@ def add_prefix_to_dict_keys(input_dict, prefix):
 def add_prefix_to_list_items(input_list, prefix):
     return [prefix + item for item in input_list]</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.create_path_to_child_object"><code class="name flex">
 <span>def <span class="ident">create_path_to_child_object</span></span>(<span>parent_path: List[str], child_name: str) ‑> List[str]</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -583,12 +1041,12 @@ def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; L
     new_path.append(child_name)
     return new_path</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.is_nested_node_name"><code class="name flex">
 <span>def <span class="ident">is_nested_node_name</span></span>(<span>node_name: str) ‑> bool</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -597,15 +1055,15 @@ def create_path_to_child_object(parent_path: List[str], child_name: str) -&gt; L
 def is_nested_node_name(node_name: str) -&gt; bool:
     return &#34;.&#34; in node_name</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.add_node"><code class="name flex">
-<span>def <span class="ident">add_node</span></span>(<span>self,<br>path_to_object: List[str],<br>value_type: <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>,<br>force_type: bool = False,<br>destination_name: str | None = None,<br>is_primary_key: bool = False,<br>default_value: str | None = None) ‑> Dict[str, <a title="keboola.json_to_csv.node.Node" href="node.html#keboola.json_to_csv.node.Node">Node</a>]</span>
+<span>def <span class="ident">add_node</span></span>(<span>self, path_to_object: List[str], value_type: <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>, force_type: bool = False, destination_name: Optional[str] = None, is_primary_key: bool = False, default_value: Optional[str] = None) ‑> Dict[str, <a title="keboola.json_to_csv.node.Node" href="node.html#keboola.json_to_csv.node.Node">Node</a>]</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -638,12 +1096,26 @@ def is_nested_node_name(node_name: str) -&gt; bool:
 
     return new_node</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.analyze_object"><code class="name flex">
-<span>def <span class="ident">analyze_object</span></span>(<span>self, path_to_object: List[Any | str], name: str, value: Any) ‑> None</span>
+<span>def <span class="ident">analyze_object</span></span>(<span>self, path_to_object: List[Union[Any, str]], name: str, value: Any) ‑> None</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Analyzes an object within the data structure and updates the node hierarchy accordingly.</p>
+<p>This method is a recursive function that analyzes each object and its nested objects
+within the data structure. It updates the node hierarchy with the appropriate data types
+and mappings for each object.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the current object. In the case of dictionaries, it represents the key name.
+In the case of lists, it represents the index.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
+<dd>The value of the current object. It can be a scalar, dictionary, list, or None..</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -682,26 +1154,12 @@ def is_nested_node_name(node_name: str) -&gt; bool:
         for sub_obj_name, sub_obj_value in value.items():
             self.analyze_object(object_path, sub_obj_name, sub_obj_value)</code></pre>
 </details>
-<div class="desc"><p>Analyzes an object within the data structure and updates the node hierarchy accordingly.</p>
-<p>This method is a recursive function that analyzes each object and its nested objects
-within the data structure. It updates the node hierarchy with the appropriate data types
-and mappings for each object.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the current object. In the case of dictionaries, it represents the key name.
-In the case of lists, it represents the index.</dd>
-<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
-<dd>The value of the current object. It can be a scalar, dictionary, list, or None..</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_column_mappings_at_path"><code class="name flex">
 <span>def <span class="ident">get_column_mappings_at_path</span></span>(<span>self, node_path: List[str]) ‑> Dict[str, str]</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -725,12 +1183,12 @@ In the case of lists, it represents the index.</dd>
 
     return headers</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_column_types"><code class="name flex">
 <span>def <span class="ident">get_column_types</span></span>(<span>self, path: List[str]) ‑> Dict[str, Tuple[<a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a>, bool]]</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -748,12 +1206,12 @@ In the case of lists, it represents the index.</dd>
         headers[decoded_name] = (data_type, force_type)
     return headers</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_mapping_dict_fom_structure"><code class="name flex">
 <span>def <span class="ident">get_mapping_dict_fom_structure</span></span>(<span>self) ‑> Dict</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -761,12 +1219,12 @@ In the case of lists, it represents the index.</dd>
 <pre><code class="python">def get_mapping_dict_fom_structure(self) -&gt; Dict:
     return self._get_table_mapping_of_node_hierarchy()</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_node_dict"><code class="name flex">
 <span>def <span class="ident">get_node_dict</span></span>(<span>self, path_to_object: List, parent_path: List = None) ‑> Dict</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -783,12 +1241,12 @@ In the case of lists, it represents the index.</dd>
             node = node.get(&#34;children&#34;).get(path_step, {})
     return node or None</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_table_name"><code class="name flex">
 <span>def <span class="ident">get_table_name</span></span>(<span>self, path: List[str]) ‑> str</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -799,12 +1257,23 @@ In the case of lists, it represents the index.</dd>
         name += f&#34;_{p}&#34;
     return name</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_value_type"><code class="name flex">
-<span>def <span class="ident">get_value_type</span></span>(<span>self, path_to_object: List[Any | str], value: Any) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
+<span>def <span class="ident">get_value_type</span></span>(<span>self, path_to_object: List[Union[Any, str]], value: Any) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
+<div class="desc"><p>Get the data type of the given value within the data structure.</p>
+<p>This method determines the NodeType of the provided value based on its data characteristics.
+It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
+it further analyzes the elements to determine if it's a list of scalars or a list of dictionaries.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
+<dd>The value to determine the data type for.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -843,23 +1312,29 @@ In the case of lists, it represents the index.</dd>
         raise JsonParserException(f&#34;Unsupported data in path {path_to_object}&#34;)
     return node_type</code></pre>
 </details>
-<div class="desc"><p>Get the data type of the given value within the data structure.</p>
-<p>This method determines the NodeType of the provided value based on its data characteristics.
-It checks whether the value is a scalar, a dictionary, a list, or None. In the case of lists,
-it further analyzes the elements to determine if it's a list of scalars or a list of dictionaries.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Union[Any, str]]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>value</code></strong> :&ensp;<code>Any</code></dt>
-<dd>The value to determine the data type for.</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.get_value_type_of_array_elements"><code class="name flex">
 <span>def <span class="ident">get_value_type_of_array_elements</span></span>(<span>self, path_to_object: List[Any], element_list: List[Any]) ‑> <a title="keboola.json_to_csv.node.NodeType" href="node.html#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
+<div class="desc"><p>Get the common data type of elements within a list in the data structure.</p>
+<p>This method determines the common NodeType of elements in the provided list. It iterates
+through the elements and calls the <code>get_value_type</code> method to determine the data type of
+each element. If all elements have the same data type, it returns that data type; otherwise,
+it raises a JsonParserException indicating that the list has inconsistent element data types.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Any]</code></dt>
+<dd>The path to the current object within the data structure.
+This list represents the sequence of keys or indices to reach the current object from the root.</dd>
+<dt><strong><code>element_list</code></strong> :&ensp;<code>List[Any]</code></dt>
+<dd>The list containing elements to analyze.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>NodeType</code></dt>
+<dd>The common data type of elements within the list.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -892,29 +1367,12 @@ This list represents the sequence of keys or indices to reach the current object
                                           f&#34;are inconsistent : {element_list}&#34;)
     return final_element_type</code></pre>
 </details>
-<div class="desc"><p>Get the common data type of elements within a list in the data structure.</p>
-<p>This method determines the common NodeType of elements in the provided list. It iterates
-through the elements and calls the <code>get_value_type</code> method to determine the data type of
-each element. If all elements have the same data type, it returns that data type; otherwise,
-it raises a JsonParserException indicating that the list has inconsistent element data types.</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>path_to_object</code></strong> :&ensp;<code>List[Any]</code></dt>
-<dd>The path to the current object within the data structure.
-This list represents the sequence of keys or indices to reach the current object from the root.</dd>
-<dt><strong><code>element_list</code></strong> :&ensp;<code>List[Any]</code></dt>
-<dd>The list containing elements to analyze.</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>NodeType</code></dt>
-<dd>The common data type of elements within the list.</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.update_with_table_mapping"><code class="name flex">
-<span>def <span class="ident">update_with_table_mapping</span></span>(<span>self,<br>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>,<br>parent_path: List | None = None) ‑> None</span>
+<span>def <span class="ident">update_with_table_mapping</span></span>(<span>self, table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>, parent_path: Optional[List] = None) ‑> None</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -927,12 +1385,12 @@ This list represents the sequence of keys or indices to reach the current object
     self._process_user_data_mappings(table_mapping, parent_path)
     self._process_child_table_mappings(table_mapping, parent_path)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.upgrade_node_type"><code class="name flex">
 <span>def <span class="ident">upgrade_node_type</span></span>(<span>self, node, new_node_type)</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -944,12 +1402,12 @@ This list represents the sequence of keys or indices to reach the current object
 
     self.upgrade_node_type_recursive(self.node_hierarchy, node.path, new_node_type)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.analyzer.Analyzer.upgrade_node_type_recursive"><code class="name flex">
 <span>def <span class="ident">upgrade_node_type_recursive</span></span>(<span>self, hierarchy, path, new_node_type)</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -961,7 +1419,6 @@ This list represents the sequence of keys or indices to reach the current object
         next_level = hierarchy[&#34;children&#34;][path[0]]
         self.upgrade_node_type_recursive(next_level, path[1:], new_node_type)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 </dl>
 </dd>
@@ -969,6 +1426,7 @@ This list represents the sequence of keys or indices to reach the current object
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -1007,7 +1465,7 @@ This list represents the sequence of keys or indices to reach the current object
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/csv_row.html
+++ b/docs/csv_row.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.csv_row API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,63 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.csv_row</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from typing import Dict, List, Any
+
+
+class CsvRow:
+    &#34;&#34;&#34;
+    CSV Row Representation.
+
+    This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
+    The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.
+
+    &#34;&#34;&#34;
+
+    def __init__(self, column_map: Dict[str, str]) -&gt; None:
+        &#34;&#34;&#34;
+        Initialize the CsvRow with a given column mapping.
+
+        Parameters:
+            column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.
+        &#34;&#34;&#34;
+        self.column_map = column_map
+        self.data = {column: None for column in list(column_map.values())}
+
+    def set_value(self, column: str, value: Any) -&gt; None:
+        &#34;&#34;&#34;
+        Set the value of a specific column in the CsvRow.
+
+        Parameters:
+            column (str): The column key (JSON or CSV header) to set the value for.
+            value (Any): The value to be set for the specified column.
+        &#34;&#34;&#34;
+        if column in self.column_map:
+            self.data[self.column_map[column]] = value
+        else:
+            self.data[column] = value
+
+    def get_row(self) -&gt; Dict[str, Any]:
+        &#34;&#34;&#34;
+        Get the data in the CsvRow as a dictionary representing a single row of CSV data.
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the CsvRow&#39;s data as a single row of CSV data.
+        &#34;&#34;&#34;
+        return self.data
+
+    def get_headers(self) -&gt; List[str]:
+        &#34;&#34;&#34;
+        Get the headers of the CsvRow as a list.
+
+        Returns:
+            List[str]: A list of CSV headers representing the CsvRow.
+        &#34;&#34;&#34;
+        return list(self.data.keys())</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -51,6 +94,12 @@ el.replaceWith(d);
 <span>(</span><span>column_map: Dict[str, str])</span>
 </code></dt>
 <dd>
+<div class="desc"><p>CSV Row Representation.</p>
+<p>This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
+The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.</p>
+<p>Initialize the CsvRow with a given column mapping.</p>
+<h2 id="parameters">Parameters</h2>
+<p>column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -105,18 +154,18 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         return list(self.data.keys())</code></pre>
 </details>
-<div class="desc"><p>CSV Row Representation.</p>
-<p>This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
-The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.</p>
-<p>Initialize the CsvRow with a given column mapping.</p>
-<h2 id="parameters">Parameters</h2>
-<p>column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.get_headers"><code class="name flex">
 <span>def <span class="ident">get_headers</span></span>(<span>self) ‑> List[str]</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Get the headers of the CsvRow as a list.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>List[str]</code></dt>
+<dd>A list of CSV headers representing the CsvRow.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -130,17 +179,17 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
     &#34;&#34;&#34;
     return list(self.data.keys())</code></pre>
 </details>
-<div class="desc"><p>Get the headers of the CsvRow as a list.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>List[str]</code></dt>
-<dd>A list of CSV headers representing the CsvRow.</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.get_row"><code class="name flex">
 <span>def <span class="ident">get_row</span></span>(<span>self) ‑> Dict[str, Any]</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Get the data in the CsvRow as a dictionary representing a single row of CSV data.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Dict[str, Any]</code></dt>
+<dd>A dictionary representing the CsvRow's data as a single row of CSV data.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -154,17 +203,15 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
     &#34;&#34;&#34;
     return self.data</code></pre>
 </details>
-<div class="desc"><p>Get the data in the CsvRow as a dictionary representing a single row of CSV data.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>Dict[str, Any]</code></dt>
-<dd>A dictionary representing the CsvRow's data as a single row of CSV data.</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.set_value"><code class="name flex">
 <span>def <span class="ident">set_value</span></span>(<span>self, column: str, value: Any) ‑> None</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Set the value of a specific column in the CsvRow.</p>
+<h2 id="parameters">Parameters</h2>
+<p>column (str): The column key (JSON or CSV header) to set the value for.
+value (Any): The value to be set for the specified column.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -182,10 +229,6 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
     else:
         self.data[column] = value</code></pre>
 </details>
-<div class="desc"><p>Set the value of a specific column in the CsvRow.</p>
-<h2 id="parameters">Parameters</h2>
-<p>column (str): The column key (JSON or CSV header) to set the value for.
-value (Any): The value to be set for the specified column.</p></div>
 </dd>
 </dl>
 </dd>
@@ -193,6 +236,7 @@ value (Any): The value to be set for the specified column.</p></div>
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -218,7 +262,7 @@ value (Any): The value to be set for the specified column.</p></div>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/csv_row.html
+++ b/docs/csv_row.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.csv_row API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,63 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.csv_row</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from typing import Dict, List, Any
-
-
-class CsvRow:
-    &#34;&#34;&#34;
-    CSV Row Representation.
-
-    This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
-    The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.
-
-    &#34;&#34;&#34;
-
-    def __init__(self, column_map: Dict[str, str]) -&gt; None:
-        &#34;&#34;&#34;
-        Initialize the CsvRow with a given column mapping.
-
-        Parameters:
-            column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.
-        &#34;&#34;&#34;
-        self.column_map = column_map
-        self.data = {column: None for column in list(column_map.values())}
-
-    def set_value(self, column: str, value: Any) -&gt; None:
-        &#34;&#34;&#34;
-        Set the value of a specific column in the CsvRow.
-
-        Parameters:
-            column (str): The column key (JSON or CSV header) to set the value for.
-            value (Any): The value to be set for the specified column.
-        &#34;&#34;&#34;
-        if column in self.column_map:
-            self.data[self.column_map[column]] = value
-        else:
-            self.data[column] = value
-
-    def get_row(self) -&gt; Dict[str, Any]:
-        &#34;&#34;&#34;
-        Get the data in the CsvRow as a dictionary representing a single row of CSV data.
-
-        Returns:
-            Dict[str, Any]: A dictionary representing the CsvRow&#39;s data as a single row of CSV data.
-        &#34;&#34;&#34;
-        return self.data
-
-    def get_headers(self) -&gt; List[str]:
-        &#34;&#34;&#34;
-        Get the headers of the CsvRow as a list.
-
-        Returns:
-            List[str]: A list of CSV headers representing the CsvRow.
-        &#34;&#34;&#34;
-        return list(self.data.keys())</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -94,12 +51,6 @@ class CsvRow:
 <span>(</span><span>column_map: Dict[str, str])</span>
 </code></dt>
 <dd>
-<div class="desc"><p>CSV Row Representation.</p>
-<p>This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
-The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.</p>
-<p>Initialize the CsvRow with a given column mapping.</p>
-<h2 id="parameters">Parameters</h2>
-<p>column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -154,18 +105,18 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
         &#34;&#34;&#34;
         return list(self.data.keys())</code></pre>
 </details>
+<div class="desc"><p>CSV Row Representation.</p>
+<p>This class represents a single row of data in a CSV file. It is used for converting JSON data into CSV format.
+The class maintains a mapping between JSON keys and CSV headers, allowing for proper CSV output.</p>
+<p>Initialize the CsvRow with a given column mapping.</p>
+<h2 id="parameters">Parameters</h2>
+<p>column_map (Dict[str, str]): A dictionary mapping JSON keys to CSV headers.</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.get_headers"><code class="name flex">
 <span>def <span class="ident">get_headers</span></span>(<span>self) ‑> List[str]</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Get the headers of the CsvRow as a list.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>List[str]</code></dt>
-<dd>A list of CSV headers representing the CsvRow.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -179,17 +130,17 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
     &#34;&#34;&#34;
     return list(self.data.keys())</code></pre>
 </details>
+<div class="desc"><p>Get the headers of the CsvRow as a list.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>List[str]</code></dt>
+<dd>A list of CSV headers representing the CsvRow.</dd>
+</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.get_row"><code class="name flex">
 <span>def <span class="ident">get_row</span></span>(<span>self) ‑> Dict[str, Any]</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Get the data in the CsvRow as a dictionary representing a single row of CSV data.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>Dict[str, Any]</code></dt>
-<dd>A dictionary representing the CsvRow's data as a single row of CSV data.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -203,15 +154,17 @@ The class maintains a mapping between JSON keys and CSV headers, allowing for pr
     &#34;&#34;&#34;
     return self.data</code></pre>
 </details>
+<div class="desc"><p>Get the data in the CsvRow as a dictionary representing a single row of CSV data.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Dict[str, Any]</code></dt>
+<dd>A dictionary representing the CsvRow's data as a single row of CSV data.</dd>
+</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.csv_row.CsvRow.set_value"><code class="name flex">
 <span>def <span class="ident">set_value</span></span>(<span>self, column: str, value: Any) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Set the value of a specific column in the CsvRow.</p>
-<h2 id="parameters">Parameters</h2>
-<p>column (str): The column key (JSON or CSV header) to set the value for.
-value (Any): The value to be set for the specified column.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -229,6 +182,10 @@ value (Any): The value to be set for the specified column.</p></div>
     else:
         self.data[column] = value</code></pre>
 </details>
+<div class="desc"><p>Set the value of a specific column in the CsvRow.</p>
+<h2 id="parameters">Parameters</h2>
+<p>column (str): The column key (JSON or CSV header) to set the value for.
+value (Any): The value to be set for the specified column.</p></div>
 </dd>
 </dl>
 </dd>
@@ -236,7 +193,6 @@ value (Any): The value to be set for the specified column.</p></div>
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -262,7 +218,7 @@ value (Any): The value to be set for the specified column.</p></div>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/exceptions.html
+++ b/docs/exceptions.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.exceptions API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,13 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.exceptions</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class JsonParserException(Exception):
+    pass</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -51,6 +44,7 @@ el.replaceWith(d);
 <span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -58,7 +52,6 @@ el.replaceWith(d);
 <pre><code class="python">class JsonParserException(Exception):
     pass</code></pre>
 </details>
-<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.Exception</li>
@@ -69,6 +62,7 @@ el.replaceWith(d);
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -89,7 +83,7 @@ el.replaceWith(d);
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/exceptions.html
+++ b/docs/exceptions.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.exceptions API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,13 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.exceptions</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">class JsonParserException(Exception):
-    pass</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -44,7 +51,6 @@
 <span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -52,6 +58,7 @@
 <pre><code class="python">class JsonParserException(Exception):
     pass</code></pre>
 </details>
+<div class="desc"><p>Common base class for all non-exit exceptions.</p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>builtins.Exception</li>
@@ -62,7 +69,6 @@
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -83,7 +89,7 @@
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,13 @@ el.replaceWith(d);
 <h1 class="title">Package <code>keboola.json_to_csv</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from .mapping import TableMapping
+from .parser import Parser</code></pre>
+</details>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -82,6 +75,7 @@ el.replaceWith(d);
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -102,7 +96,7 @@ el.replaceWith(d);
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,13 +36,6 @@
 <h1 class="title">Package <code>keboola.json_to_csv</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from .mapping import TableMapping
-from .parser import Parser</code></pre>
-</details>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -75,7 +82,6 @@ from .parser import Parser</code></pre>
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -96,7 +102,7 @@ from .parser import Parser</code></pre>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/mapping.html
+++ b/docs/mapping.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.mapping API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,171 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.mapping</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from typing import Dict, List, Optional
+
+
+class TableMapping:
+    &#34;&#34;&#34;
+        Table Mapping for Converting JSON to CSV.
+
+        This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
+        converting JSON data into CSV format with the specified table structure.
+
+        Attributes:
+            table_name (str): The name of the table.
+            column_mappings (Dict[str, str]): A dictionary mapping JSON keys to CSV headers for each column in the table.
+            primary_keys (List[str]): A list of primary key column names in the table.
+            child_tables (Dict[str, TableMapping]): A dictionary mapping child table names to their corresponding TableMapping objects.
+            force_types (List[str]): A list of column names that require forcing specific data types.
+            user_data (Dict[str, str]): Additional user-defined data associated with the table mapping.
+
+        &#34;&#34;&#34;
+
+    def __init__(self,
+                 table_name: str,
+                 column_mappings: Dict[str, str],
+                 primary_keys: List[str],
+                 child_tables: Dict[str, &#39;TableMapping&#39;],
+                 force_types: List[str],
+                 user_data: Dict[str, str]) -&gt; None:
+
+        self.table_name: str = table_name
+        self.column_mappings: Dict = column_mappings
+        self.primary_keys: List = primary_keys
+        self.child_tables: Dict = child_tables
+        self.force_types = force_types
+        self.user_data = user_data
+
+    def table_mappings_flattened_by_key(self) -&gt; Dict[str, &#39;TableMapping&#39;]:
+        &#34;&#34;&#34;
+        Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
+        in the hierarchy is indexed by the table name.
+
+        E.g. Table mapping with root table name `user` and child table `user_address` returns following strucutre:
+        {&#34;user&#34;: TableMapping, &#34;user_address&#34;:TableMapping&#34;)
+
+        Parameters:
+        - path (Optional[str]): The object path for which the mapping should be retrieved.
+                                If None, the full flattened mapping is returned.
+
+        Returns:
+        - Dict: Flattened representation of the mapping structure.
+        &#34;&#34;&#34;
+
+        def _flatten_mapping(mapping: &#39;TableMapping&#39;, key=&#39;&#39;) -&gt; Dict:
+            flat_mappings = {}
+
+            table_name = mapping.table_name
+            if not key:
+                key = table_name
+
+            flat_mappings[key] = mapping
+
+            for child_key, child_mapping in mapping.child_tables.items():
+                # TODO: use dynamic separator
+                key = f&#39;{key}_{child_key}&#39;
+                flat_mappings.update(_flatten_mapping(child_mapping, key))
+
+            return flat_mappings
+
+        # recursively flatten
+        full_mapping = _flatten_mapping(self)
+
+        return full_mapping
+
+    def as_dict(self):
+        return {
+            &#34;table_name&#34;: self.table_name,
+            &#34;column_mappings&#34;: self.column_mappings,
+            &#34;primary_keys&#34;: self.primary_keys,
+            &#34;force_types&#34;: self.force_types,
+            &#34;child_tables&#34;: {key: value.as_dict() for key, value in self.child_tables.items()}
+        }
+
+    @classmethod
+    def build_from_legacy_mapping(cls,
+                                  legacy_mapping: dict,
+                                  user_data: Optional[Dict[str, str]] = None) -&gt; &#34;TableMapping&#34;:
+        &#34;&#34;&#34;
+        Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).
+
+        This class method allows constructing a TableMapping object from a legacy mapping in the old format.
+
+        Parameters:
+            legacy_mapping (dict): The legacy mapping dictionary in the old format.
+            user_data (Optional[Dict[str, str]]): Additional user-defined data associated with the table mapping (default: None).
+
+        Returns:
+            TableMapping: A TableMapping object representing the table mapping in the new format.
+
+        &#34;&#34;&#34;
+
+        if not user_data:
+            user_data = {}
+
+        # TODO Add delimiter options
+        table_name = list(legacy_mapping.keys())[0]
+
+        column_mappings = {}
+        primary_keys = []
+        force_types = []
+
+        child_tables = {}
+
+        for node_id, node in legacy_mapping.get(table_name).items():
+            # if the value is string it is a simplified column mapping
+            if isinstance(node, str) or node.get(&#34;type&#34;) == &#34;column&#34; or not node.get(&#34;type&#34;):
+                raw_name = node_id
+                destination_name = node if isinstance(node, str) else node.get(&#34;mapping&#34;).get(&#34;destination&#34;)
+                column_mappings[raw_name] = destination_name
+
+            # it is not simplified mapping
+            if isinstance(node, dict):
+                if node.get(&#34;type&#34;) == &#34;column&#34;:
+                    if node.get(&#34;mapping&#34;).get(&#34;primaryKey&#34;):
+                        primary_keys.append(raw_name)
+                    if node.get(&#34;forceType&#34;):
+                        force_types.append(raw_name)
+                if node.get(&#34;type&#34;) == &#34;table&#34;:
+                    child_mapping = {node_id: node.get(&#34;tableMapping&#34;)}
+                    child_table_mapping = cls.build_from_legacy_mapping(child_mapping)
+                    child_tables[node_id] = child_table_mapping
+
+        return cls(table_name=table_name,
+                   column_mappings=column_mappings,
+                   primary_keys=primary_keys,
+                   child_tables=child_tables,
+                   force_types=force_types,
+                   user_data=user_data)
+
+    @classmethod
+    def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
+        &#34;&#34;&#34;
+        Build a TableMapping object from a dictionary representation of the mapping.
+
+        This class method allows constructing a TableMapping object from a dictionary representation of the mapping.
+
+        Parameters:
+            mapping (Dict): The dictionary representation of the table mapping.
+
+        Returns:
+            TableMapping: A TableMapping object representing the table mapping.
+
+        &#34;&#34;&#34;
+        child_tables = {}
+        for child in mapping.get(&#34;child_tables&#34;):
+            child_tables[child] = cls.build_from_mapping_dict(mapping.get(&#34;child_tables&#34;).get(child))
+        return cls(table_name=mapping.get(&#34;table_name&#34;),
+                   column_mappings=mapping.get(&#34;column_mappings&#34;),
+                   primary_keys=mapping.get(&#34;primary_keys&#34;),
+                   child_tables=child_tables,
+                   force_types=mapping.get(&#34;force_types&#34;),
+                   user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -48,9 +199,27 @@ el.replaceWith(d);
 <dl>
 <dt id="keboola.json_to_csv.mapping.TableMapping"><code class="flex name class">
 <span>class <span class="ident">TableMapping</span></span>
-<span>(</span><span>table_name: str,<br>column_mappings: Dict[str, str],<br>primary_keys: List[str],<br>child_tables: Dict[str, ForwardRef('<a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>')],<br>force_types: List[str],<br>user_data: Dict[str, str])</span>
+<span>(</span><span>table_name: str, column_mappings: Dict[str, str], primary_keys: List[str], child_tables: Dict[str, ForwardRef('<a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>')], force_types: List[str], user_data: Dict[str, str])</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Table Mapping for Converting JSON to CSV.</p>
+<p>This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
+converting JSON data into CSV format with the specified table structure.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>table_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the table.</dd>
+<dt><strong><code>column_mappings</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
+<dd>A dictionary mapping JSON keys to CSV headers for each column in the table.</dd>
+<dt><strong><code>primary_keys</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>A list of primary key column names in the table.</dd>
+<dt><strong><code>child_tables</code></strong> :&ensp;<code>Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</code></dt>
+<dd>A dictionary mapping child table names to their corresponding TableMapping objects.</dd>
+<dt><strong><code>force_types</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>A list of column names that require forcing specific data types.</dd>
+<dt><strong><code>user_data</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
+<dd>Additional user-defined data associated with the table mapping.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -213,28 +382,10 @@ el.replaceWith(d);
                    force_types=mapping.get(&#34;force_types&#34;),
                    user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
 </details>
-<div class="desc"><p>Table Mapping for Converting JSON to CSV.</p>
-<p>This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
-converting JSON data into CSV format with the specified table structure.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>table_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the table.</dd>
-<dt><strong><code>column_mappings</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
-<dd>A dictionary mapping JSON keys to CSV headers for each column in the table.</dd>
-<dt><strong><code>primary_keys</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>A list of primary key column names in the table.</dd>
-<dt><strong><code>child_tables</code></strong> :&ensp;<code>Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</code></dt>
-<dd>A dictionary mapping child table names to their corresponding TableMapping objects.</dd>
-<dt><strong><code>force_types</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>A list of column names that require forcing specific data types.</dd>
-<dt><strong><code>user_data</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
-<dd>Additional user-defined data associated with the table mapping.</dd>
-</dl></div>
 <h3>Static methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.mapping.TableMapping.build_from_legacy_mapping"><code class="name flex">
-<span>def <span class="ident">build_from_legacy_mapping</span></span>(<span>legacy_mapping: dict, user_data: Dict[str, str] | None = None) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
+<span>def <span class="ident">build_from_legacy_mapping</span></span>(<span>legacy_mapping: dict, user_data: Optional[Dict[str, str]] = None) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).</p>
@@ -247,6 +398,66 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
 <dt><code><a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>A TableMapping object representing the table mapping in the new format.</dd>
 </dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@classmethod
+def build_from_legacy_mapping(cls,
+                              legacy_mapping: dict,
+                              user_data: Optional[Dict[str, str]] = None) -&gt; &#34;TableMapping&#34;:
+    &#34;&#34;&#34;
+    Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).
+
+    This class method allows constructing a TableMapping object from a legacy mapping in the old format.
+
+    Parameters:
+        legacy_mapping (dict): The legacy mapping dictionary in the old format.
+        user_data (Optional[Dict[str, str]]): Additional user-defined data associated with the table mapping (default: None).
+
+    Returns:
+        TableMapping: A TableMapping object representing the table mapping in the new format.
+
+    &#34;&#34;&#34;
+
+    if not user_data:
+        user_data = {}
+
+    # TODO Add delimiter options
+    table_name = list(legacy_mapping.keys())[0]
+
+    column_mappings = {}
+    primary_keys = []
+    force_types = []
+
+    child_tables = {}
+
+    for node_id, node in legacy_mapping.get(table_name).items():
+        # if the value is string it is a simplified column mapping
+        if isinstance(node, str) or node.get(&#34;type&#34;) == &#34;column&#34; or not node.get(&#34;type&#34;):
+            raw_name = node_id
+            destination_name = node if isinstance(node, str) else node.get(&#34;mapping&#34;).get(&#34;destination&#34;)
+            column_mappings[raw_name] = destination_name
+
+        # it is not simplified mapping
+        if isinstance(node, dict):
+            if node.get(&#34;type&#34;) == &#34;column&#34;:
+                if node.get(&#34;mapping&#34;).get(&#34;primaryKey&#34;):
+                    primary_keys.append(raw_name)
+                if node.get(&#34;forceType&#34;):
+                    force_types.append(raw_name)
+            if node.get(&#34;type&#34;) == &#34;table&#34;:
+                child_mapping = {node_id: node.get(&#34;tableMapping&#34;)}
+                child_table_mapping = cls.build_from_legacy_mapping(child_mapping)
+                child_tables[node_id] = child_table_mapping
+
+    return cls(table_name=table_name,
+               column_mappings=column_mappings,
+               primary_keys=primary_keys,
+               child_tables=child_tables,
+               force_types=force_types,
+               user_data=user_data)</code></pre>
+</details>
 </dd>
 <dt id="keboola.json_to_csv.mapping.TableMapping.build_from_mapping_dict"><code class="name flex">
 <span>def <span class="ident">build_from_mapping_dict</span></span>(<span>mapping: Dict) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
@@ -261,6 +472,34 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
 <dt><code><a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>A TableMapping object representing the table mapping.</dd>
 </dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@classmethod
+def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
+    &#34;&#34;&#34;
+    Build a TableMapping object from a dictionary representation of the mapping.
+
+    This class method allows constructing a TableMapping object from a dictionary representation of the mapping.
+
+    Parameters:
+        mapping (Dict): The dictionary representation of the table mapping.
+
+    Returns:
+        TableMapping: A TableMapping object representing the table mapping.
+
+    &#34;&#34;&#34;
+    child_tables = {}
+    for child in mapping.get(&#34;child_tables&#34;):
+        child_tables[child] = cls.build_from_mapping_dict(mapping.get(&#34;child_tables&#34;).get(child))
+    return cls(table_name=mapping.get(&#34;table_name&#34;),
+               column_mappings=mapping.get(&#34;column_mappings&#34;),
+               primary_keys=mapping.get(&#34;primary_keys&#34;),
+               child_tables=child_tables,
+               force_types=mapping.get(&#34;force_types&#34;),
+               user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
+</details>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -269,6 +508,7 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
 <span>def <span class="ident">as_dict</span></span>(<span>self)</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -282,12 +522,20 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
         &#34;child_tables&#34;: {key: value.as_dict() for key, value in self.child_tables.items()}
     }</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.mapping.TableMapping.table_mappings_flattened_by_key"><code class="name flex">
 <span>def <span class="ident">table_mappings_flattened_by_key</span></span>(<span>self) ‑> Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
+in the hierarchy is indexed by the table name.</p>
+<p>E.g. Table mapping with root table name <code>user</code> and child table <code>user_address</code> returns following strucutre:
+{"user": TableMapping, "user_address":TableMapping")</p>
+<p>Parameters:
+- path (Optional[str]): The object path for which the mapping should be retrieved.
+If None, the full flattened mapping is returned.</p>
+<p>Returns:
+- Dict: Flattened representation of the mapping structure.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -329,15 +577,6 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
 
     return full_mapping</code></pre>
 </details>
-<div class="desc"><p>Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
-in the hierarchy is indexed by the table name.</p>
-<p>E.g. Table mapping with root table name <code>user</code> and child table <code>user_address</code> returns following strucutre:
-{"user": TableMapping, "user_address":TableMapping")</p>
-<p>Parameters:
-- path (Optional[str]): The object path for which the mapping should be retrieved.
-If None, the full flattened mapping is returned.</p>
-<p>Returns:
-- Dict: Flattened representation of the mapping structure.</p></div>
 </dd>
 </dl>
 </dd>
@@ -345,6 +584,7 @@ If None, the full flattened mapping is returned.</p>
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -371,7 +611,7 @@ If None, the full flattened mapping is returned.</p>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/mapping.html
+++ b/docs/mapping.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.mapping API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,171 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.mapping</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from typing import Dict, List, Optional
-
-
-class TableMapping:
-    &#34;&#34;&#34;
-        Table Mapping for Converting JSON to CSV.
-
-        This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
-        converting JSON data into CSV format with the specified table structure.
-
-        Attributes:
-            table_name (str): The name of the table.
-            column_mappings (Dict[str, str]): A dictionary mapping JSON keys to CSV headers for each column in the table.
-            primary_keys (List[str]): A list of primary key column names in the table.
-            child_tables (Dict[str, TableMapping]): A dictionary mapping child table names to their corresponding TableMapping objects.
-            force_types (List[str]): A list of column names that require forcing specific data types.
-            user_data (Dict[str, str]): Additional user-defined data associated with the table mapping.
-
-        &#34;&#34;&#34;
-
-    def __init__(self,
-                 table_name: str,
-                 column_mappings: Dict[str, str],
-                 primary_keys: List[str],
-                 child_tables: Dict[str, &#39;TableMapping&#39;],
-                 force_types: List[str],
-                 user_data: Dict[str, str]) -&gt; None:
-
-        self.table_name: str = table_name
-        self.column_mappings: Dict = column_mappings
-        self.primary_keys: List = primary_keys
-        self.child_tables: Dict = child_tables
-        self.force_types = force_types
-        self.user_data = user_data
-
-    def table_mappings_flattened_by_key(self) -&gt; Dict[str, &#39;TableMapping&#39;]:
-        &#34;&#34;&#34;
-        Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
-        in the hierarchy is indexed by the table name.
-
-        E.g. Table mapping with root table name `user` and child table `user_address` returns following strucutre:
-        {&#34;user&#34;: TableMapping, &#34;user_address&#34;:TableMapping&#34;)
-
-        Parameters:
-        - path (Optional[str]): The object path for which the mapping should be retrieved.
-                                If None, the full flattened mapping is returned.
-
-        Returns:
-        - Dict: Flattened representation of the mapping structure.
-        &#34;&#34;&#34;
-
-        def _flatten_mapping(mapping: &#39;TableMapping&#39;, key=&#39;&#39;) -&gt; Dict:
-            flat_mappings = {}
-
-            table_name = mapping.table_name
-            if not key:
-                key = table_name
-
-            flat_mappings[key] = mapping
-
-            for child_key, child_mapping in mapping.child_tables.items():
-                # TODO: use dynamic separator
-                key = f&#39;{key}_{child_key}&#39;
-                flat_mappings.update(_flatten_mapping(child_mapping, key))
-
-            return flat_mappings
-
-        # recursively flatten
-        full_mapping = _flatten_mapping(self)
-
-        return full_mapping
-
-    def as_dict(self):
-        return {
-            &#34;table_name&#34;: self.table_name,
-            &#34;column_mappings&#34;: self.column_mappings,
-            &#34;primary_keys&#34;: self.primary_keys,
-            &#34;force_types&#34;: self.force_types,
-            &#34;child_tables&#34;: {key: value.as_dict() for key, value in self.child_tables.items()}
-        }
-
-    @classmethod
-    def build_from_legacy_mapping(cls,
-                                  legacy_mapping: dict,
-                                  user_data: Optional[Dict[str, str]] = None) -&gt; &#34;TableMapping&#34;:
-        &#34;&#34;&#34;
-        Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).
-
-        This class method allows constructing a TableMapping object from a legacy mapping in the old format.
-
-        Parameters:
-            legacy_mapping (dict): The legacy mapping dictionary in the old format.
-            user_data (Optional[Dict[str, str]]): Additional user-defined data associated with the table mapping (default: None).
-
-        Returns:
-            TableMapping: A TableMapping object representing the table mapping in the new format.
-
-        &#34;&#34;&#34;
-
-        if not user_data:
-            user_data = {}
-
-        # TODO Add delimiter options
-        table_name = list(legacy_mapping.keys())[0]
-
-        column_mappings = {}
-        primary_keys = []
-        force_types = []
-
-        child_tables = {}
-
-        for node_id, node in legacy_mapping.get(table_name).items():
-            # if the value is string it is a simplified column mapping
-            if isinstance(node, str) or node.get(&#34;type&#34;) == &#34;column&#34; or not node.get(&#34;type&#34;):
-                raw_name = node_id
-                destination_name = node if isinstance(node, str) else node.get(&#34;mapping&#34;).get(&#34;destination&#34;)
-                column_mappings[raw_name] = destination_name
-
-            # it is not simplified mapping
-            if isinstance(node, dict):
-                if node.get(&#34;type&#34;) == &#34;column&#34;:
-                    if node.get(&#34;mapping&#34;).get(&#34;primaryKey&#34;):
-                        primary_keys.append(raw_name)
-                    if node.get(&#34;forceType&#34;):
-                        force_types.append(raw_name)
-                if node.get(&#34;type&#34;) == &#34;table&#34;:
-                    child_mapping = {node_id: node.get(&#34;tableMapping&#34;)}
-                    child_table_mapping = cls.build_from_legacy_mapping(child_mapping)
-                    child_tables[node_id] = child_table_mapping
-
-        return cls(table_name=table_name,
-                   column_mappings=column_mappings,
-                   primary_keys=primary_keys,
-                   child_tables=child_tables,
-                   force_types=force_types,
-                   user_data=user_data)
-
-    @classmethod
-    def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
-        &#34;&#34;&#34;
-        Build a TableMapping object from a dictionary representation of the mapping.
-
-        This class method allows constructing a TableMapping object from a dictionary representation of the mapping.
-
-        Parameters:
-            mapping (Dict): The dictionary representation of the table mapping.
-
-        Returns:
-            TableMapping: A TableMapping object representing the table mapping.
-
-        &#34;&#34;&#34;
-        child_tables = {}
-        for child in mapping.get(&#34;child_tables&#34;):
-            child_tables[child] = cls.build_from_mapping_dict(mapping.get(&#34;child_tables&#34;).get(child))
-        return cls(table_name=mapping.get(&#34;table_name&#34;),
-                   column_mappings=mapping.get(&#34;column_mappings&#34;),
-                   primary_keys=mapping.get(&#34;primary_keys&#34;),
-                   child_tables=child_tables,
-                   force_types=mapping.get(&#34;force_types&#34;),
-                   user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -199,27 +48,9 @@ class TableMapping:
 <dl>
 <dt id="keboola.json_to_csv.mapping.TableMapping"><code class="flex name class">
 <span>class <span class="ident">TableMapping</span></span>
-<span>(</span><span>table_name: str, column_mappings: Dict[str, str], primary_keys: List[str], child_tables: Dict[str, ForwardRef('<a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>')], force_types: List[str], user_data: Dict[str, str])</span>
+<span>(</span><span>table_name: str,<br>column_mappings: Dict[str, str],<br>primary_keys: List[str],<br>child_tables: Dict[str, ForwardRef('<a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>')],<br>force_types: List[str],<br>user_data: Dict[str, str])</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Table Mapping for Converting JSON to CSV.</p>
-<p>This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
-converting JSON data into CSV format with the specified table structure.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>table_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the table.</dd>
-<dt><strong><code>column_mappings</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
-<dd>A dictionary mapping JSON keys to CSV headers for each column in the table.</dd>
-<dt><strong><code>primary_keys</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>A list of primary key column names in the table.</dd>
-<dt><strong><code>child_tables</code></strong> :&ensp;<code>Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</code></dt>
-<dd>A dictionary mapping child table names to their corresponding TableMapping objects.</dd>
-<dt><strong><code>force_types</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>A list of column names that require forcing specific data types.</dd>
-<dt><strong><code>user_data</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
-<dd>Additional user-defined data associated with the table mapping.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -382,10 +213,28 @@ converting JSON data into CSV format with the specified table structure.</p>
                    force_types=mapping.get(&#34;force_types&#34;),
                    user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
 </details>
+<div class="desc"><p>Table Mapping for Converting JSON to CSV.</p>
+<p>This class represents the mapping of tables and their columns, primary keys, and force types. It is used for
+converting JSON data into CSV format with the specified table structure.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>table_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the table.</dd>
+<dt><strong><code>column_mappings</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
+<dd>A dictionary mapping JSON keys to CSV headers for each column in the table.</dd>
+<dt><strong><code>primary_keys</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>A list of primary key column names in the table.</dd>
+<dt><strong><code>child_tables</code></strong> :&ensp;<code>Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</code></dt>
+<dd>A dictionary mapping child table names to their corresponding TableMapping objects.</dd>
+<dt><strong><code>force_types</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>A list of column names that require forcing specific data types.</dd>
+<dt><strong><code>user_data</code></strong> :&ensp;<code>Dict[str, str]</code></dt>
+<dd>Additional user-defined data associated with the table mapping.</dd>
+</dl></div>
 <h3>Static methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.mapping.TableMapping.build_from_legacy_mapping"><code class="name flex">
-<span>def <span class="ident">build_from_legacy_mapping</span></span>(<span>legacy_mapping: dict, user_data: Optional[Dict[str, str]] = None) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
+<span>def <span class="ident">build_from_legacy_mapping</span></span>(<span>legacy_mapping: dict, user_data: Dict[str, str] | None = None) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).</p>
@@ -398,66 +247,6 @@ user_data (Optional[Dict[str, str]]): Additional user-defined data associated wi
 <dt><code><a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>A TableMapping object representing the table mapping in the new format.</dd>
 </dl></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@classmethod
-def build_from_legacy_mapping(cls,
-                              legacy_mapping: dict,
-                              user_data: Optional[Dict[str, str]] = None) -&gt; &#34;TableMapping&#34;:
-    &#34;&#34;&#34;
-    Build a TableMapping object from a legacy mapping in the old format (PHP JsonParser mapping).
-
-    This class method allows constructing a TableMapping object from a legacy mapping in the old format.
-
-    Parameters:
-        legacy_mapping (dict): The legacy mapping dictionary in the old format.
-        user_data (Optional[Dict[str, str]]): Additional user-defined data associated with the table mapping (default: None).
-
-    Returns:
-        TableMapping: A TableMapping object representing the table mapping in the new format.
-
-    &#34;&#34;&#34;
-
-    if not user_data:
-        user_data = {}
-
-    # TODO Add delimiter options
-    table_name = list(legacy_mapping.keys())[0]
-
-    column_mappings = {}
-    primary_keys = []
-    force_types = []
-
-    child_tables = {}
-
-    for node_id, node in legacy_mapping.get(table_name).items():
-        # if the value is string it is a simplified column mapping
-        if isinstance(node, str) or node.get(&#34;type&#34;) == &#34;column&#34; or not node.get(&#34;type&#34;):
-            raw_name = node_id
-            destination_name = node if isinstance(node, str) else node.get(&#34;mapping&#34;).get(&#34;destination&#34;)
-            column_mappings[raw_name] = destination_name
-
-        # it is not simplified mapping
-        if isinstance(node, dict):
-            if node.get(&#34;type&#34;) == &#34;column&#34;:
-                if node.get(&#34;mapping&#34;).get(&#34;primaryKey&#34;):
-                    primary_keys.append(raw_name)
-                if node.get(&#34;forceType&#34;):
-                    force_types.append(raw_name)
-            if node.get(&#34;type&#34;) == &#34;table&#34;:
-                child_mapping = {node_id: node.get(&#34;tableMapping&#34;)}
-                child_table_mapping = cls.build_from_legacy_mapping(child_mapping)
-                child_tables[node_id] = child_table_mapping
-
-    return cls(table_name=table_name,
-               column_mappings=column_mappings,
-               primary_keys=primary_keys,
-               child_tables=child_tables,
-               force_types=force_types,
-               user_data=user_data)</code></pre>
-</details>
 </dd>
 <dt id="keboola.json_to_csv.mapping.TableMapping.build_from_mapping_dict"><code class="name flex">
 <span>def <span class="ident">build_from_mapping_dict</span></span>(<span>mapping: Dict) ‑> <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></span>
@@ -472,34 +261,6 @@ def build_from_legacy_mapping(cls,
 <dt><code><a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>A TableMapping object representing the table mapping.</dd>
 </dl></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@classmethod
-def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
-    &#34;&#34;&#34;
-    Build a TableMapping object from a dictionary representation of the mapping.
-
-    This class method allows constructing a TableMapping object from a dictionary representation of the mapping.
-
-    Parameters:
-        mapping (Dict): The dictionary representation of the table mapping.
-
-    Returns:
-        TableMapping: A TableMapping object representing the table mapping.
-
-    &#34;&#34;&#34;
-    child_tables = {}
-    for child in mapping.get(&#34;child_tables&#34;):
-        child_tables[child] = cls.build_from_mapping_dict(mapping.get(&#34;child_tables&#34;).get(child))
-    return cls(table_name=mapping.get(&#34;table_name&#34;),
-               column_mappings=mapping.get(&#34;column_mappings&#34;),
-               primary_keys=mapping.get(&#34;primary_keys&#34;),
-               child_tables=child_tables,
-               force_types=mapping.get(&#34;force_types&#34;),
-               user_data=mapping.get(&#34;user_data&#34;, {}))</code></pre>
-</details>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -508,7 +269,6 @@ def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
 <span>def <span class="ident">as_dict</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -522,20 +282,12 @@ def build_from_mapping_dict(cls, mapping: Dict) -&gt; &#34;TableMapping&#34;:
         &#34;child_tables&#34;: {key: value.as_dict() for key, value in self.child_tables.items()}
     }</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.mapping.TableMapping.table_mappings_flattened_by_key"><code class="name flex">
 <span>def <span class="ident">table_mappings_flattened_by_key</span></span>(<span>self) ‑> Dict[str, <a title="keboola.json_to_csv.mapping.TableMapping" href="#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>]</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
-in the hierarchy is indexed by the table name.</p>
-<p>E.g. Table mapping with root table name <code>user</code> and child table <code>user_address</code> returns following strucutre:
-{"user": TableMapping, "user_address":TableMapping")</p>
-<p>Parameters:
-- path (Optional[str]): The object path for which the mapping should be retrieved.
-If None, the full flattened mapping is returned.</p>
-<p>Returns:
-- Dict: Flattened representation of the mapping structure.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -577,6 +329,15 @@ If None, the full flattened mapping is returned.</p>
 
     return full_mapping</code></pre>
 </details>
+<div class="desc"><p>Retrieve a flattened representation of the mapping structures. Returns dictionary structure where each mapping
+in the hierarchy is indexed by the table name.</p>
+<p>E.g. Table mapping with root table name <code>user</code> and child table <code>user_address</code> returns following strucutre:
+{"user": TableMapping, "user_address":TableMapping")</p>
+<p>Parameters:
+- path (Optional[str]): The object path for which the mapping should be retrieved.
+If None, the full flattened mapping is returned.</p>
+<p>Returns:
+- Dict: Flattened representation of the mapping structure.</p></div>
 </dd>
 </dl>
 </dd>
@@ -584,7 +345,6 @@ If None, the full flattened mapping is returned.</p>
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -611,7 +371,7 @@ If None, the full flattened mapping is returned.</p>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/node.html
+++ b/docs/node.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.node API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,149 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.node</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from enum import Enum, auto
-from typing import List, Optional
-
-
-class NodeType(Enum):
-    &#34;&#34;&#34;
-    Enumerates the types of nodes in the JSON data.
-
-    This enumeration represents the various types of nodes that can be encountered while processing JSON data.
-    Each node type corresponds to a different data structure in the JSON.
-
-    Enumeration Values:
-        DICT: Represents a dictionary node in the JSON.
-        NULL: Represents a null value node in the JSON.
-        LIST: Represents a list node in the JSON.
-        LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
-        LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
-        SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.
-
-    &#34;&#34;&#34;
-    DICT = auto()
-    NULL = auto()
-    LIST = auto()
-    LIST_OF_DICTS = auto()
-    LIST_OF_SCALARS = auto()
-    SCALAR = auto()
-
-    @staticmethod
-    def from_str(label: str) -&gt; &#39;NodeType&#39;:
-        &#34;&#34;&#34;
-        Convert a string label to its corresponding NodeType.
-
-        This static method allows converting a string representation of a node type to its corresponding
-        NodeType enumeration value.
-
-        Parameters:
-            label (str): The string label representing the node type.
-
-        Returns:
-            NodeType: The NodeType enumeration value corresponding to the given label.
-
-        Raises:
-            NotImplementedError: If the given label is not recognized as a valid NodeType.
-        &#34;&#34;&#34;
-        if label in (&#39;int&#39;, &#39;integer&#39;):
-            return NodeType.SCALAR
-        elif label in (&#39;bool&#39;, &#39;boolean&#39;):
-            return NodeType.SCALAR
-        elif label == &#39;float&#39;:
-            return NodeType.SCALAR
-        elif label == &#39;dict&#39;:
-            return NodeType.DICT
-        elif label == &#39;list&#39;:
-            return NodeType.LIST
-        elif label in (&#39;str&#39;, &#39;string&#39;):
-            return NodeType.SCALAR
-        else:
-            raise NotImplementedError
-
-
-class Node:
-    &#34;&#34;&#34;
-    Node Representation in the JSON data structure.
-
-    This class represents a node in the JSON data structure. Each node can have various properties such as its path,
-    header name, data type, parent node name, and more.
-
-    Attributes:
-        path (List[str]): The path to the current node in the JSON data.
-        header_name (str): The header name representing the node in the CSV output.
-        data_name (str): The name of the data represented by the node.
-        data_type (NodeType): The data type of the node.
-        parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
-        is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
-        force_type (bool):  A flag indicating whether to not parse the data further (save it as is) (default: False).
-        default_value (Optional[str]): The default value for the node if the data is missing (default: None).
-
-    &#34;&#34;&#34;
-
-    def __init__(self,
-                 path: List[str],
-                 data_name: str,
-                 data_type: NodeType,
-                 parent_name: Optional[str] = None,
-                 is_primary_key: bool = False,
-                 force_type: bool = False,
-                 destination_name: Optional[str] = None,
-                 default_value: Optional[str] = None) -&gt; None:
-        &#34;&#34;&#34;
-        Initialize a Node object.
-
-        Parameters:
-            path (List[str]): The path to the current node in the JSON data.
-            data_name (str): The name of the data represented by the node.
-            data_type (NodeType): The data type of the node.
-            parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
-            is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
-            force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
-            destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
-            default_value (Optional[str]): The default value for the node if the data is missing (default: None).
-        &#34;&#34;&#34;
-        self.path: List = path
-        self.header_name: str = data_name
-        if parent_name:
-            self.header_name = f&#34;{parent_name}_{data_name}&#34;
-
-        if destination_name:
-            self.header_name = destination_name
-
-        self.data_name = data_name
-        self.data_type = data_type
-        self.parent_name = parent_name
-        self.is_primary_key = is_primary_key
-        self.force_type = force_type
-        self.default_value = default_value
-
-    def __eq__(self, other) -&gt; bool:
-        &#34;&#34;&#34;
-        Check if two Node objects are equal.
-
-        This method compares two Node objects and checks whether they are equal based on their properties.
-
-        Parameters:
-            other: The other Node object to compare.
-
-        Returns:
-            bool: True if the two Node objects are equal; otherwise, False.
-        &#34;&#34;&#34;
-        equals = True
-        if not other:
-            raise TypeError(&#34;Trying to compare node to a NoneType&#34;)
-        if self.path != other.path:
-            equals = False
-        if self.header_name != other.header_name:
-            equals = False
-        if self.data_type != other.data_type:
-            equals = False
-        return equals</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -177,41 +48,9 @@ class Node:
 <dl>
 <dt id="keboola.json_to_csv.node.Node"><code class="flex name class">
 <span>class <span class="ident">Node</span></span>
-<span>(</span><span>path: List[str], data_name: str, data_type: <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a>, parent_name: Optional[str] = None, is_primary_key: bool = False, force_type: bool = False, destination_name: Optional[str] = None, default_value: Optional[str] = None)</span>
+<span>(</span><span>path: List[str],<br>data_name: str,<br>data_type: <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a>,<br>parent_name: str | None = None,<br>is_primary_key: bool = False,<br>force_type: bool = False,<br>destination_name: str | None = None,<br>default_value: str | None = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Node Representation in the JSON data structure.</p>
-<p>This class represents a node in the JSON data structure. Each node can have various properties such as its path,
-header name, data type, parent node name, and more.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>path</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>The path to the current node in the JSON data.</dd>
-<dt><strong><code>header_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The header name representing the node in the CSV output.</dd>
-<dt><strong><code>data_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the data represented by the node.</dd>
-<dt><strong><code>data_type</code></strong> :&ensp;<code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
-<dd>The data type of the node.</dd>
-<dt><strong><code>parent_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
-<dd>The name of the parent node (if any) that contains this node (default: None).</dd>
-<dt><strong><code>is_primary_key</code></strong> :&ensp;<code>bool</code></dt>
-<dd>A flag indicating whether the node is a primary key (default: False).</dd>
-<dt><strong><code>force_type</code></strong> :&ensp;<code>bool</code></dt>
-<dd>A flag indicating whether to not parse the data further (save it as is) (default: False).</dd>
-<dt><strong><code>default_value</code></strong> :&ensp;<code>Optional[str]</code></dt>
-<dd>The default value for the node if the data is missing (default: None).</dd>
-</dl>
-<p>Initialize a Node object.</p>
-<h2 id="parameters">Parameters</h2>
-<p>path (List[str]): The path to the current node in the JSON data.
-data_name (str): The name of the data represented by the node.
-data_type (NodeType): The data type of the node.
-parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
-is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
-force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
-destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
-default_value (Optional[str]): The default value for the node if the data is missing (default: None).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -295,22 +134,44 @@ default_value (Optional[str]): The default value for the node if the data is mis
             equals = False
         return equals</code></pre>
 </details>
+<div class="desc"><p>Node Representation in the JSON data structure.</p>
+<p>This class represents a node in the JSON data structure. Each node can have various properties such as its path,
+header name, data type, parent node name, and more.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>path</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>The path to the current node in the JSON data.</dd>
+<dt><strong><code>header_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The header name representing the node in the CSV output.</dd>
+<dt><strong><code>data_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the data represented by the node.</dd>
+<dt><strong><code>data_type</code></strong> :&ensp;<code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
+<dd>The data type of the node.</dd>
+<dt><strong><code>parent_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
+<dd>The name of the parent node (if any) that contains this node (default: None).</dd>
+<dt><strong><code>is_primary_key</code></strong> :&ensp;<code>bool</code></dt>
+<dd>A flag indicating whether the node is a primary key (default: False).</dd>
+<dt><strong><code>force_type</code></strong> :&ensp;<code>bool</code></dt>
+<dd>A flag indicating whether to not parse the data further (save it as is) (default: False).</dd>
+<dt><strong><code>default_value</code></strong> :&ensp;<code>Optional[str]</code></dt>
+<dd>The default value for the node if the data is missing (default: None).</dd>
+</dl>
+<p>Initialize a Node object.</p>
+<h2 id="parameters">Parameters</h2>
+<p>path (List[str]): The path to the current node in the JSON data.
+data_name (str): The name of the data represented by the node.
+data_type (NodeType): The data type of the node.
+parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
+is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
+force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
+destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
+default_value (Optional[str]): The default value for the node if the data is missing (default: None).</p></div>
 </dd>
 <dt id="keboola.json_to_csv.node.NodeType"><code class="flex name class">
 <span>class <span class="ident">NodeType</span></span>
 <span>(</span><span>*args, **kwds)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Enumerates the types of nodes in the JSON data.</p>
-<p>This enumeration represents the various types of nodes that can be encountered while processing JSON data.
-Each node type corresponds to a different data structure in the JSON.</p>
-<p>Enumeration Values:
-DICT: Represents a dictionary node in the JSON.
-NULL: Represents a null value node in the JSON.
-LIST: Represents a list node in the JSON.
-LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
-LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
-SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -370,6 +231,16 @@ SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</
         else:
             raise NotImplementedError</code></pre>
 </details>
+<div class="desc"><p>Enumerates the types of nodes in the JSON data.</p>
+<p>This enumeration represents the various types of nodes that can be encountered while processing JSON data.
+Each node type corresponds to a different data structure in the JSON.</p>
+<p>Enumeration Values:
+DICT: Represents a dictionary node in the JSON.
+NULL: Represents a null value node in the JSON.
+LIST: Represents a list node in the JSON.
+LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
+LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
+SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -407,21 +278,6 @@ SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</
 <span>def <span class="ident">from_str</span></span>(<span>label: str) ‑> <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
-<div class="desc"><p>Convert a string label to its corresponding NodeType.</p>
-<p>This static method allows converting a string representation of a node type to its corresponding
-NodeType enumeration value.</p>
-<h2 id="parameters">Parameters</h2>
-<p>label (str): The string label representing the node type.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
-<dd>The NodeType enumeration value corresponding to the given label.</dd>
-</dl>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>NotImplementedError</code></dt>
-<dd>If the given label is not recognized as a valid NodeType.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -458,6 +314,21 @@ def from_str(label: str) -&gt; &#39;NodeType&#39;:
     else:
         raise NotImplementedError</code></pre>
 </details>
+<div class="desc"><p>Convert a string label to its corresponding NodeType.</p>
+<p>This static method allows converting a string representation of a node type to its corresponding
+NodeType enumeration value.</p>
+<h2 id="parameters">Parameters</h2>
+<p>label (str): The string label representing the node type.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
+<dd>The NodeType enumeration value corresponding to the given label.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NotImplementedError</code></dt>
+<dd>If the given label is not recognized as a valid NodeType.</dd>
+</dl></div>
 </dd>
 </dl>
 </dd>
@@ -465,7 +336,6 @@ def from_str(label: str) -&gt; &#39;NodeType&#39;:
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -498,7 +368,7 @@ def from_str(label: str) -&gt; &#39;NodeType&#39;:
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/node.html
+++ b/docs/node.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.node API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,149 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.node</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from enum import Enum, auto
+from typing import List, Optional
+
+
+class NodeType(Enum):
+    &#34;&#34;&#34;
+    Enumerates the types of nodes in the JSON data.
+
+    This enumeration represents the various types of nodes that can be encountered while processing JSON data.
+    Each node type corresponds to a different data structure in the JSON.
+
+    Enumeration Values:
+        DICT: Represents a dictionary node in the JSON.
+        NULL: Represents a null value node in the JSON.
+        LIST: Represents a list node in the JSON.
+        LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
+        LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
+        SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.
+
+    &#34;&#34;&#34;
+    DICT = auto()
+    NULL = auto()
+    LIST = auto()
+    LIST_OF_DICTS = auto()
+    LIST_OF_SCALARS = auto()
+    SCALAR = auto()
+
+    @staticmethod
+    def from_str(label: str) -&gt; &#39;NodeType&#39;:
+        &#34;&#34;&#34;
+        Convert a string label to its corresponding NodeType.
+
+        This static method allows converting a string representation of a node type to its corresponding
+        NodeType enumeration value.
+
+        Parameters:
+            label (str): The string label representing the node type.
+
+        Returns:
+            NodeType: The NodeType enumeration value corresponding to the given label.
+
+        Raises:
+            NotImplementedError: If the given label is not recognized as a valid NodeType.
+        &#34;&#34;&#34;
+        if label in (&#39;int&#39;, &#39;integer&#39;):
+            return NodeType.SCALAR
+        elif label in (&#39;bool&#39;, &#39;boolean&#39;):
+            return NodeType.SCALAR
+        elif label == &#39;float&#39;:
+            return NodeType.SCALAR
+        elif label == &#39;dict&#39;:
+            return NodeType.DICT
+        elif label == &#39;list&#39;:
+            return NodeType.LIST
+        elif label in (&#39;str&#39;, &#39;string&#39;):
+            return NodeType.SCALAR
+        else:
+            raise NotImplementedError
+
+
+class Node:
+    &#34;&#34;&#34;
+    Node Representation in the JSON data structure.
+
+    This class represents a node in the JSON data structure. Each node can have various properties such as its path,
+    header name, data type, parent node name, and more.
+
+    Attributes:
+        path (List[str]): The path to the current node in the JSON data.
+        header_name (str): The header name representing the node in the CSV output.
+        data_name (str): The name of the data represented by the node.
+        data_type (NodeType): The data type of the node.
+        parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
+        is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
+        force_type (bool):  A flag indicating whether to not parse the data further (save it as is) (default: False).
+        default_value (Optional[str]): The default value for the node if the data is missing (default: None).
+
+    &#34;&#34;&#34;
+
+    def __init__(self,
+                 path: List[str],
+                 data_name: str,
+                 data_type: NodeType,
+                 parent_name: Optional[str] = None,
+                 is_primary_key: bool = False,
+                 force_type: bool = False,
+                 destination_name: Optional[str] = None,
+                 default_value: Optional[str] = None) -&gt; None:
+        &#34;&#34;&#34;
+        Initialize a Node object.
+
+        Parameters:
+            path (List[str]): The path to the current node in the JSON data.
+            data_name (str): The name of the data represented by the node.
+            data_type (NodeType): The data type of the node.
+            parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
+            is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
+            force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
+            destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
+            default_value (Optional[str]): The default value for the node if the data is missing (default: None).
+        &#34;&#34;&#34;
+        self.path: List = path
+        self.header_name: str = data_name
+        if parent_name:
+            self.header_name = f&#34;{parent_name}_{data_name}&#34;
+
+        if destination_name:
+            self.header_name = destination_name
+
+        self.data_name = data_name
+        self.data_type = data_type
+        self.parent_name = parent_name
+        self.is_primary_key = is_primary_key
+        self.force_type = force_type
+        self.default_value = default_value
+
+    def __eq__(self, other) -&gt; bool:
+        &#34;&#34;&#34;
+        Check if two Node objects are equal.
+
+        This method compares two Node objects and checks whether they are equal based on their properties.
+
+        Parameters:
+            other: The other Node object to compare.
+
+        Returns:
+            bool: True if the two Node objects are equal; otherwise, False.
+        &#34;&#34;&#34;
+        equals = True
+        if not other:
+            raise TypeError(&#34;Trying to compare node to a NoneType&#34;)
+        if self.path != other.path:
+            equals = False
+        if self.header_name != other.header_name:
+            equals = False
+        if self.data_type != other.data_type:
+            equals = False
+        return equals</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -48,9 +177,41 @@ el.replaceWith(d);
 <dl>
 <dt id="keboola.json_to_csv.node.Node"><code class="flex name class">
 <span>class <span class="ident">Node</span></span>
-<span>(</span><span>path: List[str],<br>data_name: str,<br>data_type: <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a>,<br>parent_name: str | None = None,<br>is_primary_key: bool = False,<br>force_type: bool = False,<br>destination_name: str | None = None,<br>default_value: str | None = None)</span>
+<span>(</span><span>path: List[str], data_name: str, data_type: <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a>, parent_name: Optional[str] = None, is_primary_key: bool = False, force_type: bool = False, destination_name: Optional[str] = None, default_value: Optional[str] = None)</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Node Representation in the JSON data structure.</p>
+<p>This class represents a node in the JSON data structure. Each node can have various properties such as its path,
+header name, data type, parent node name, and more.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>path</code></strong> :&ensp;<code>List[str]</code></dt>
+<dd>The path to the current node in the JSON data.</dd>
+<dt><strong><code>header_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The header name representing the node in the CSV output.</dd>
+<dt><strong><code>data_name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the data represented by the node.</dd>
+<dt><strong><code>data_type</code></strong> :&ensp;<code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
+<dd>The data type of the node.</dd>
+<dt><strong><code>parent_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
+<dd>The name of the parent node (if any) that contains this node (default: None).</dd>
+<dt><strong><code>is_primary_key</code></strong> :&ensp;<code>bool</code></dt>
+<dd>A flag indicating whether the node is a primary key (default: False).</dd>
+<dt><strong><code>force_type</code></strong> :&ensp;<code>bool</code></dt>
+<dd>A flag indicating whether to not parse the data further (save it as is) (default: False).</dd>
+<dt><strong><code>default_value</code></strong> :&ensp;<code>Optional[str]</code></dt>
+<dd>The default value for the node if the data is missing (default: None).</dd>
+</dl>
+<p>Initialize a Node object.</p>
+<h2 id="parameters">Parameters</h2>
+<p>path (List[str]): The path to the current node in the JSON data.
+data_name (str): The name of the data represented by the node.
+data_type (NodeType): The data type of the node.
+parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
+is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
+force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
+destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
+default_value (Optional[str]): The default value for the node if the data is missing (default: None).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -134,44 +295,22 @@ el.replaceWith(d);
             equals = False
         return equals</code></pre>
 </details>
-<div class="desc"><p>Node Representation in the JSON data structure.</p>
-<p>This class represents a node in the JSON data structure. Each node can have various properties such as its path,
-header name, data type, parent node name, and more.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>path</code></strong> :&ensp;<code>List[str]</code></dt>
-<dd>The path to the current node in the JSON data.</dd>
-<dt><strong><code>header_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The header name representing the node in the CSV output.</dd>
-<dt><strong><code>data_name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the data represented by the node.</dd>
-<dt><strong><code>data_type</code></strong> :&ensp;<code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
-<dd>The data type of the node.</dd>
-<dt><strong><code>parent_name</code></strong> :&ensp;<code>Optional[str]</code></dt>
-<dd>The name of the parent node (if any) that contains this node (default: None).</dd>
-<dt><strong><code>is_primary_key</code></strong> :&ensp;<code>bool</code></dt>
-<dd>A flag indicating whether the node is a primary key (default: False).</dd>
-<dt><strong><code>force_type</code></strong> :&ensp;<code>bool</code></dt>
-<dd>A flag indicating whether to not parse the data further (save it as is) (default: False).</dd>
-<dt><strong><code>default_value</code></strong> :&ensp;<code>Optional[str]</code></dt>
-<dd>The default value for the node if the data is missing (default: None).</dd>
-</dl>
-<p>Initialize a Node object.</p>
-<h2 id="parameters">Parameters</h2>
-<p>path (List[str]): The path to the current node in the JSON data.
-data_name (str): The name of the data represented by the node.
-data_type (NodeType): The data type of the node.
-parent_name (Optional[str]): The name of the parent node (if any) that contains this node (default: None).
-is_primary_key (bool): A flag indicating whether the node is a primary key (default: False).
-force_type (bool): A flag indicating whether to not parse the data further (save it as is)(default: False).
-destination_name (Optional[str]): An alternative header name to use in the CSV output (default: None).
-default_value (Optional[str]): The default value for the node if the data is missing (default: None).</p></div>
 </dd>
 <dt id="keboola.json_to_csv.node.NodeType"><code class="flex name class">
 <span>class <span class="ident">NodeType</span></span>
 <span>(</span><span>*args, **kwds)</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Enumerates the types of nodes in the JSON data.</p>
+<p>This enumeration represents the various types of nodes that can be encountered while processing JSON data.
+Each node type corresponds to a different data structure in the JSON.</p>
+<p>Enumeration Values:
+DICT: Represents a dictionary node in the JSON.
+NULL: Represents a null value node in the JSON.
+LIST: Represents a list node in the JSON.
+LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
+LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
+SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -231,16 +370,6 @@ default_value (Optional[str]): The default value for the node if the data is mis
         else:
             raise NotImplementedError</code></pre>
 </details>
-<div class="desc"><p>Enumerates the types of nodes in the JSON data.</p>
-<p>This enumeration represents the various types of nodes that can be encountered while processing JSON data.
-Each node type corresponds to a different data structure in the JSON.</p>
-<p>Enumeration Values:
-DICT: Represents a dictionary node in the JSON.
-NULL: Represents a null value node in the JSON.
-LIST: Represents a list node in the JSON.
-LIST_OF_DICTS: Represents a list of dictionaries node in the JSON.
-LIST_OF_SCALARS: Represents a list of scalars node in the JSON.
-SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li>enum.Enum</li>
@@ -278,6 +407,21 @@ SCALAR: Represents a scalar node (e.g., int, bool, float, string) in the JSON.</
 <span>def <span class="ident">from_str</span></span>(<span>label: str) ‑> <a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></span>
 </code></dt>
 <dd>
+<div class="desc"><p>Convert a string label to its corresponding NodeType.</p>
+<p>This static method allows converting a string representation of a node type to its corresponding
+NodeType enumeration value.</p>
+<h2 id="parameters">Parameters</h2>
+<p>label (str): The string label representing the node type.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
+<dd>The NodeType enumeration value corresponding to the given label.</dd>
+</dl>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>NotImplementedError</code></dt>
+<dd>If the given label is not recognized as a valid NodeType.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -314,21 +458,6 @@ def from_str(label: str) -&gt; &#39;NodeType&#39;:
     else:
         raise NotImplementedError</code></pre>
 </details>
-<div class="desc"><p>Convert a string label to its corresponding NodeType.</p>
-<p>This static method allows converting a string representation of a node type to its corresponding
-NodeType enumeration value.</p>
-<h2 id="parameters">Parameters</h2>
-<p>label (str): The string label representing the node type.</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code><a title="keboola.json_to_csv.node.NodeType" href="#keboola.json_to_csv.node.NodeType">NodeType</a></code></dt>
-<dd>The NodeType enumeration value corresponding to the given label.</dd>
-</dl>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>NotImplementedError</code></dt>
-<dd>If the given label is not recognized as a valid NodeType.</dd>
-</dl></div>
 </dd>
 </dl>
 </dd>
@@ -336,6 +465,7 @@ NodeType enumeration value.</p>
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -368,7 +498,7 @@ NodeType enumeration value.</p>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.parser API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,316 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.parser</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">import hashlib
+from csv import DictWriter
+from typing import Any, Dict, List, Optional, Union
+
+from .analyzer import Analyzer
+from .csv_row import CsvRow
+from .exceptions import JsonParserException
+from .mapping import TableMapping
+from .node import NodeType
+from .table import Table
+from .utils import is_dict, is_list, is_scalar
+
+
+class Parser:
+    &#34;&#34;&#34;
+    JSON to CSV Parser.
+
+    This class is responsible for converting JSON data to CSV files based on a specified table mapping.
+    It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
+    parsed CSV data to files.
+
+    &#34;&#34;&#34;
+
+    def __init__(self,
+                 main_table_name: Optional[str] = None,
+                 table_mapping: Optional[TableMapping] = None,
+                 analyze_further: bool = True) -&gt; None:
+        &#34;&#34;&#34;
+        Initialize the JSON Parser.
+
+        Parameters:
+            main_table_name (Optional[str]): The name of the main table to use for the CSV files.
+            table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
+                                                    and force types.
+            analyze_further (bool): If True, performs further analysis of data that is not specified
+                                    in the table mapping.
+        &#34;&#34;&#34;
+        self.analyze_further = analyze_further
+        self.main_table_name = main_table_name
+
+        self._csv_file_results = {}
+        self.analyzer = Analyzer(root_name=main_table_name, table_mapping=table_mapping)
+
+    def parse_data_to_csv(self,
+                          input_data: Union[Dict, List[Dict]],
+                          destination_path: str,
+                          root_name: Optional[str] = None) -&gt; None:
+        &#34;&#34;&#34;
+        Parse input data to CSV files and save them to the specified destination path.
+
+        Parameters:
+            input_data (Union[Dict, List[Dict]]): The JSON data to parse.
+            destination_path (str): The path to save the generated CSV files.
+            root_name (Optional[str]): The root node name to use for parsing the data (default: None).
+        &#34;&#34;&#34;
+        data_to_parse = self._get_parseable_data_from_input_data(input_data, root_name)
+        parsed_data = self._parse_data(data_to_parse)
+        for table_id, table in parsed_data.items():
+            with open(f&#34;{destination_path}/{table.name}.csv&#34;, &#34;w&#34;) as outfile:
+                writer = DictWriter(outfile, table.headers)
+                writer.writeheader()
+                writer.writerows(table.rows)
+
+    def parse_data(self, input_data: Union[Dict, List[Dict]], root_name: Optional[str] = None) -&gt; Dict:
+        &#34;&#34;&#34;
+        Parse input data and return a dictionary of CSV rows as flat dictionaries.
+
+        Parameters:
+            input_data (Union[Dict, List[Dict]]): The JSON data to parse.
+            root_name (Optional[str]): The root node name to use for parsing the data (default: None).
+
+        Returns:
+            Dict: A dictionary containing the parsed CSV data.
+        &#34;&#34;&#34;
+        data_to_parse = self._get_parseable_data_from_input_data(input_data, root_name)
+        self._parse_data(data_to_parse)
+        return {key: self._csv_file_results[key].rows for key in self._csv_file_results}
+
+    @property
+    def table_mapping(self) -&gt; TableMapping:
+        table_mapping_dict = self.analyzer.get_mapping_dict_fom_structure()
+        return TableMapping.build_from_mapping_dict(table_mapping_dict)
+
+    @staticmethod
+    def _get_parseable_data_from_input_data(input_data: Union[Dict, List[Dict]],
+                                            root_name: Optional[str]) -&gt; List[Dict]:
+        &#34;&#34;&#34;
+            Get the parseable data from the input JSON data based on the root name.
+
+            This static method processes the input JSON data to obtain a list of dictionaries that can be parsed
+            by the parser. It handles cases where a specific root node is provided as the entry point for parsing.
+
+            Parameters:
+                input_data (Union[Dict, List[Dict]]): The JSON data to process.
+                root_name (Optional[str]): The root node name to use for parsing the data (default: None).
+
+            Returns:
+                List[Dict]: A list of dictionaries that can be parsed by the parser.
+
+            Raises:
+                JsonParserException: If the specified root node is invalid and not found in the input data.
+            &#34;&#34;&#34;
+        if root_name:
+            if root_name == &#34;.&#34;:
+                input_data = [input_data]
+            else:
+                for node in root_name.split(&#34;.&#34;):
+                    if node not in input_data:
+                        raise JsonParserException(f&#34;The root node &#39;{root_name}&#39; is invalid&#34;)
+                    input_data = input_data.get(node)
+        if is_dict(input_data):
+            input_data = [input_data]
+        return input_data
+
+    def _parse_data(self, input_data: List[Dict],
+                    node_path: Optional[List[str]] = None,
+                    file_name: Optional[str] = None,
+                    parent_data: Optional[Dict[str, str]] = None) -&gt; Dict[str, Table]:
+        &#34;&#34;&#34;
+        Parse the input JSON data recursively and generate Table objects.
+
+        This private method is responsible for recursively parsing the input JSON data and converting it
+        into Table objects.
+        The parsed CSV data is stored in the `_csv_file_results` dictionary as Table objects.
+
+        Parameters:
+            input_data (List[Dict]): The JSON data to parse.
+            node_path (Optional[List[str]]): The path to the current node being analyzed (default: None).
+            file_name (Optional[str]): The name of the CSV file (table) to associate the parsed data (default: None).
+            parent_data (Optional[Dict[str, str]]): A dictionary containing parent-level data to be merged
+            with the current row.
+
+        Returns:
+            Dict[str, Table]: A dictionary containing Table objects representing the parsed CSV data.
+
+        Notes:
+            - If `file_name` is not provided, the main table name specified during initialization will be used.
+            - The `node_path` parameter is used for internal tracking during the recursive parsing process.
+            - The `parent_data` parameter allows for merging parent-level data into the current row.
+
+        &#34;&#34;&#34;
+        if not file_name:
+            file_name = self.main_table_name
+        if not node_path:
+            node_path = []
+        csv_file = self._create_csv_file(file_name)
+        if not parent_data:
+            parent_data = {}
+        for row in input_data:
+            if is_scalar(row):
+                row = {&#34;data&#34;: row}
+            if parent_data:
+                row.update(parent_data)
+                for key in parent_data:
+                    new_node_path = node_path + [key]
+                    self.analyzer.add_node(new_node_path, NodeType.SCALAR)
+            csv_row = self._parse_row(row, node_path)
+            csv_file.save_row(csv_row.get_row())
+            csv_file.headers = csv_row.get_headers()
+
+        return self._csv_file_results
+
+    def _parse_row(self,
+                   row: Dict[str, Any],
+                   current_path: Optional[List[str]] = None,
+                   outer_object_hash: Optional[str] = None) -&gt; CsvRow:
+        current_path = current_path or []
+        if self.analyze_further:
+            for name, value in row.items():
+                self.analyzer.analyze_object(current_path, name, value)
+        columns = self.analyzer.get_column_types(current_path)
+        array_parent_id = self._generate_column_hash(row, current_path, outer_object_hash)
+        primary_key_values = self._get_primary_key_values(data_row=row, node_path=current_path)
+        column_map = self.analyzer.get_column_mappings_at_path(current_path)
+        csv_row = CsvRow(column_map)
+        for column, (data_type, force_type) in dict(columns).items():
+            self._parse_field_by_type(row, csv_row, str(column), data_type, current_path, array_parent_id,
+                                      primary_key_values, force_type)
+        return csv_row
+
+    def _parse_field_by_type(self,
+                             row: Dict[str, Any],
+                             csv_row: CsvRow,
+                             column: str,
+                             data_type: NodeType,
+                             node_path: List[str],
+                             array_parent_id: str,
+                             primary_key_values: Dict[str, str],
+                             force_type: bool) -&gt; None:
+        &#34;&#34;&#34;
+            Parse a field of JSON data based on its data type and other properties.
+
+            This private method is responsible for parsing a field of JSON data based on its data type, node path,
+            and other properties like primary keys and force type.
+            It then stores the parsed value in the corresponding CSV row.
+
+            Parameters:
+                row (Dict[str, Any]): The JSON data for the current row.
+                csv_row (CsvRow): The CsvRow object representing the current row in the CSV.
+                column (str): The column name of the current field in the JSON data.
+                data_type (NodeType): The data type of the current field based on the node structure.
+                node_path (List[str]): The path to the current field in the JSON data.
+                array_parent_id (str): The ID of the parent object (for array elements) used for CSV table relations.
+                primary_key_values (Dict[str, str]): A dictionary containing primary key values for the table.
+                force_type (bool): A flag indicating whether to force the data to be unparsed.
+
+            Notes:
+                - If the column data is None, it tries to fetch the default value from the node in the analyzer.
+                - For lists and dictionaries, it calls the corresponding private methods to handle them recursively.
+                - For scalars or when force type is True, it sets the value directly in the CSV row.
+                - The `whole_path` variable is used for setting the value in the CSV row with the correct key
+                  (dot-separated).
+
+            &#34;&#34;&#34;
+
+        column_data = row.get(column)
+        if column_data is None:
+            path = node_path + [column]
+            node = self.analyzer.get_node_dict(path)
+            column_data = node.get(&#34;node&#34;).default_value
+
+        if column_data is None:
+            pass
+        elif data_type in [NodeType.LIST, NodeType.LIST_OF_DICTS, NodeType.LIST_OF_SCALARS] and not force_type:
+            self._parse_list_field(column_data, csv_row, node_path, column, array_parent_id, primary_key_values)
+        elif data_type == NodeType.DICT and not force_type:
+            # add primary_key_values to parse dict field?
+            self._parse_dict_field(column_data, csv_row, node_path, column, array_parent_id)
+        elif is_scalar(column_data) or force_type:
+            whole_path = node_path + [column]
+            csv_row.set_value(&#34;.&#34;.join(whole_path), column_data)
+
+    def _parse_list_field(self,
+                          column_data: Any,
+                          csv_row: CsvRow,
+                          node_path: List[str],
+                          column: str,
+                          array_parent_id: str,
+                          primary_key_values: Dict[str, str]) -&gt; None:
+        &#34;&#34;&#34;
+
+        Parse a list field of JSON data.
+
+        This private method is responsible for parsing a list field of JSON data, handling array elements, and
+        recursively processing the list items. It creates separate tables for each nested list,
+        maintains the parent-child relationship in the CSV data, and applies primary key values if available.
+
+        Parameters:
+            column_data (Any): The JSON data for the current column (list field).
+            csv_row (CsvRow): The CsvRow object representing the current row in the CSV.
+            node_path (List[str]): The path to the current field in the JSON data.
+            column (str): The column name of the current field in the JSON data.
+            array_parent_id (str): The ID of the parent object (for array elements) used for CSV table relations.
+            primary_key_values (Dict[str, str]): A dictionary containing primary key values for the table.
+
+        &#34;&#34;&#34;
+        if not is_list(column_data):
+            column_data = [column_data]
+        if array_parent_id or primary_key_values:
+            new_path = self.analyzer.create_path_to_child_object(node_path, column)
+            new_table_name = self.analyzer.get_table_name(new_path)
+            parent_data = {&#34;JSON_parentId&#34;: array_parent_id}
+            if primary_key_values:
+                parent_data = primary_key_values
+            else:
+                child_path = self.analyzer.create_path_to_child_object(node_path, column)
+                sf = self.analyzer.get_node_dict(child_path).get(&#34;node&#34;).header_name
+                csv_row.set_value(sf, array_parent_id)
+
+            self._parse_data(column_data, new_path, new_table_name, parent_data=parent_data)
+
+    def _parse_dict_field(self,
+                          column_data: Dict,
+                          csv_row: CsvRow,
+                          node_path: List[Union[Any, str]],
+                          column: str,
+                          array_parent_id: str) -&gt; None:
+
+        new_path = self.analyzer.create_path_to_child_object(node_path, column)
+        child_row = self._parse_row(column_data, new_path, outer_object_hash=array_parent_id)
+        for key, value in child_row.get_row().items():
+            csv_row.set_value(key, value)
+
+    def _create_csv_file(self, file_name: str) -&gt; Table:
+        if file_name not in self._csv_file_results:
+            self._csv_file_results[file_name] = Table(file_name, [])
+        return self._csv_file_results[file_name]
+
+    def _generate_column_hash(self, data_row: Dict[str, Any], node_path: List[Union[Any, str]],
+                              outer_object_hash: Optional[str] = None) -&gt; str:
+        node_path = [self.main_table_name] + node_path
+        clean_node_string = &#34;.&#34;.join(list(filter(lambda val: val != &#34;[]&#34;, node_path)))
+        hashed_values = hashlib.md5(str(data_row).encode() + str(outer_object_hash).encode()).hexdigest()
+        return f&#34;{clean_node_string}_{hashed_values}&#34;
+
+    def _get_primary_key_values(self, data_row: Dict[str, Any], node_path: List[Union[Any, str]]) -&gt; Dict[str, str]:
+        current_table_primary_keys = {}
+        children_nodes = self.analyzer.get_node_dict(path_to_object=node_path).get(&#34;children&#34;)
+        for child_node in children_nodes:
+            if children_nodes.get(child_node).get(&#34;node&#34;).is_primary_key:
+                # TODO FIX WHEN ID IS NESTED e.g. some_dict.id
+                name = &#34;_&#34;.join([self.main_table_name] + node_path + [child_node])
+                current_table_primary_keys[name] = data_row.get(child_node)
+
+        return current_table_primary_keys</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -48,9 +344,20 @@ el.replaceWith(d);
 <dl>
 <dt id="keboola.json_to_csv.parser.Parser"><code class="flex name class">
 <span>class <span class="ident">Parser</span></span>
-<span>(</span><span>main_table_name: str | None = None,<br>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a> | None = None,<br>analyze_further: bool = True)</span>
+<span>(</span><span>main_table_name: Optional[str] = None, table_mapping: Optional[<a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>] = None, analyze_further: bool = True)</span>
 </code></dt>
 <dd>
+<div class="desc"><p>JSON to CSV Parser.</p>
+<p>This class is responsible for converting JSON data to CSV files based on a specified table mapping.
+It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
+parsed CSV data to files.</p>
+<p>Initialize the JSON Parser.</p>
+<h2 id="parameters">Parameters</h2>
+<p>main_table_name (Optional[str]): The name of the main table to use for the CSV files.
+table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
+and force types.
+analyze_further (bool): If True, performs further analysis of data that is not specified
+in the table mapping.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -348,21 +655,11 @@ el.replaceWith(d);
 
         return current_table_primary_keys</code></pre>
 </details>
-<div class="desc"><p>JSON to CSV Parser.</p>
-<p>This class is responsible for converting JSON data to CSV files based on a specified table mapping.
-It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
-parsed CSV data to files.</p>
-<p>Initialize the JSON Parser.</p>
-<h2 id="parameters">Parameters</h2>
-<p>main_table_name (Optional[str]): The name of the main table to use for the CSV files.
-table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
-and force types.
-analyze_further (bool): If True, performs further analysis of data that is not specified
-in the table mapping.</p></div>
 <h3>Instance variables</h3>
 <dl>
-<dt id="keboola.json_to_csv.parser.Parser.table_mapping"><code class="name">prop <span class="ident">table_mapping</span> : <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
+<dt id="keboola.json_to_csv.parser.Parser.table_mapping"><code class="name">var <span class="ident">table_mapping</span> : <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -372,15 +669,23 @@ def table_mapping(self) -&gt; TableMapping:
     table_mapping_dict = self.analyzer.get_mapping_dict_fom_structure()
     return TableMapping.build_from_mapping_dict(table_mapping_dict)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.parser.Parser.parse_data"><code class="name flex">
-<span>def <span class="ident">parse_data</span></span>(<span>self, input_data: Dict | List[Dict], root_name: str | None = None) ‑> Dict</span>
+<span>def <span class="ident">parse_data</span></span>(<span>self, input_data: Union[Dict, List[Dict]], root_name: Optional[str] = None) ‑> Dict</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Parse input data and return a dictionary of CSV rows as flat dictionaries.</p>
+<h2 id="parameters">Parameters</h2>
+<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
+root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Dict</code></dt>
+<dd>A dictionary containing the parsed CSV data.</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -400,20 +705,16 @@ def table_mapping(self) -&gt; TableMapping:
     self._parse_data(data_to_parse)
     return {key: self._csv_file_results[key].rows for key in self._csv_file_results}</code></pre>
 </details>
-<div class="desc"><p>Parse input data and return a dictionary of CSV rows as flat dictionaries.</p>
-<h2 id="parameters">Parameters</h2>
-<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>Dict</code></dt>
-<dd>A dictionary containing the parsed CSV data.</dd>
-</dl></div>
 </dd>
 <dt id="keboola.json_to_csv.parser.Parser.parse_data_to_csv"><code class="name flex">
-<span>def <span class="ident">parse_data_to_csv</span></span>(<span>self,<br>input_data: Dict | List[Dict],<br>destination_path: str,<br>root_name: str | None = None) ‑> None</span>
+<span>def <span class="ident">parse_data_to_csv</span></span>(<span>self, input_data: Union[Dict, List[Dict]], destination_path: str, root_name: Optional[str] = None) ‑> None</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Parse input data to CSV files and save them to the specified destination path.</p>
+<h2 id="parameters">Parameters</h2>
+<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
+destination_path (str): The path to save the generated CSV files.
+root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -438,11 +739,6 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
             writer.writeheader()
             writer.writerows(table.rows)</code></pre>
 </details>
-<div class="desc"><p>Parse input data to CSV files and save them to the specified destination path.</p>
-<h2 id="parameters">Parameters</h2>
-<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-destination_path (str): The path to save the generated CSV files.
-root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p></div>
 </dd>
 </dl>
 </dd>
@@ -450,6 +746,7 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -475,7 +772,7 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/parser.html
+++ b/docs/parser.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.parser API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,316 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.parser</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">import hashlib
-from csv import DictWriter
-from typing import Any, Dict, List, Optional, Union
-
-from .analyzer import Analyzer
-from .csv_row import CsvRow
-from .exceptions import JsonParserException
-from .mapping import TableMapping
-from .node import NodeType
-from .table import Table
-from .utils import is_dict, is_list, is_scalar
-
-
-class Parser:
-    &#34;&#34;&#34;
-    JSON to CSV Parser.
-
-    This class is responsible for converting JSON data to CSV files based on a specified table mapping.
-    It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
-    parsed CSV data to files.
-
-    &#34;&#34;&#34;
-
-    def __init__(self,
-                 main_table_name: Optional[str] = None,
-                 table_mapping: Optional[TableMapping] = None,
-                 analyze_further: bool = True) -&gt; None:
-        &#34;&#34;&#34;
-        Initialize the JSON Parser.
-
-        Parameters:
-            main_table_name (Optional[str]): The name of the main table to use for the CSV files.
-            table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
-                                                    and force types.
-            analyze_further (bool): If True, performs further analysis of data that is not specified
-                                    in the table mapping.
-        &#34;&#34;&#34;
-        self.analyze_further = analyze_further
-        self.main_table_name = main_table_name
-
-        self._csv_file_results = {}
-        self.analyzer = Analyzer(root_name=main_table_name, table_mapping=table_mapping)
-
-    def parse_data_to_csv(self,
-                          input_data: Union[Dict, List[Dict]],
-                          destination_path: str,
-                          root_name: Optional[str] = None) -&gt; None:
-        &#34;&#34;&#34;
-        Parse input data to CSV files and save them to the specified destination path.
-
-        Parameters:
-            input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-            destination_path (str): The path to save the generated CSV files.
-            root_name (Optional[str]): The root node name to use for parsing the data (default: None).
-        &#34;&#34;&#34;
-        data_to_parse = self._get_parseable_data_from_input_data(input_data, root_name)
-        parsed_data = self._parse_data(data_to_parse)
-        for table_id, table in parsed_data.items():
-            with open(f&#34;{destination_path}/{table.name}.csv&#34;, &#34;w&#34;) as outfile:
-                writer = DictWriter(outfile, table.headers)
-                writer.writeheader()
-                writer.writerows(table.rows)
-
-    def parse_data(self, input_data: Union[Dict, List[Dict]], root_name: Optional[str] = None) -&gt; Dict:
-        &#34;&#34;&#34;
-        Parse input data and return a dictionary of CSV rows as flat dictionaries.
-
-        Parameters:
-            input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-            root_name (Optional[str]): The root node name to use for parsing the data (default: None).
-
-        Returns:
-            Dict: A dictionary containing the parsed CSV data.
-        &#34;&#34;&#34;
-        data_to_parse = self._get_parseable_data_from_input_data(input_data, root_name)
-        self._parse_data(data_to_parse)
-        return {key: self._csv_file_results[key].rows for key in self._csv_file_results}
-
-    @property
-    def table_mapping(self) -&gt; TableMapping:
-        table_mapping_dict = self.analyzer.get_mapping_dict_fom_structure()
-        return TableMapping.build_from_mapping_dict(table_mapping_dict)
-
-    @staticmethod
-    def _get_parseable_data_from_input_data(input_data: Union[Dict, List[Dict]],
-                                            root_name: Optional[str]) -&gt; List[Dict]:
-        &#34;&#34;&#34;
-            Get the parseable data from the input JSON data based on the root name.
-
-            This static method processes the input JSON data to obtain a list of dictionaries that can be parsed
-            by the parser. It handles cases where a specific root node is provided as the entry point for parsing.
-
-            Parameters:
-                input_data (Union[Dict, List[Dict]]): The JSON data to process.
-                root_name (Optional[str]): The root node name to use for parsing the data (default: None).
-
-            Returns:
-                List[Dict]: A list of dictionaries that can be parsed by the parser.
-
-            Raises:
-                JsonParserException: If the specified root node is invalid and not found in the input data.
-            &#34;&#34;&#34;
-        if root_name:
-            if root_name == &#34;.&#34;:
-                input_data = [input_data]
-            else:
-                for node in root_name.split(&#34;.&#34;):
-                    if node not in input_data:
-                        raise JsonParserException(f&#34;The root node &#39;{root_name}&#39; is invalid&#34;)
-                    input_data = input_data.get(node)
-        if is_dict(input_data):
-            input_data = [input_data]
-        return input_data
-
-    def _parse_data(self, input_data: List[Dict],
-                    node_path: Optional[List[str]] = None,
-                    file_name: Optional[str] = None,
-                    parent_data: Optional[Dict[str, str]] = None) -&gt; Dict[str, Table]:
-        &#34;&#34;&#34;
-        Parse the input JSON data recursively and generate Table objects.
-
-        This private method is responsible for recursively parsing the input JSON data and converting it
-        into Table objects.
-        The parsed CSV data is stored in the `_csv_file_results` dictionary as Table objects.
-
-        Parameters:
-            input_data (List[Dict]): The JSON data to parse.
-            node_path (Optional[List[str]]): The path to the current node being analyzed (default: None).
-            file_name (Optional[str]): The name of the CSV file (table) to associate the parsed data (default: None).
-            parent_data (Optional[Dict[str, str]]): A dictionary containing parent-level data to be merged
-            with the current row.
-
-        Returns:
-            Dict[str, Table]: A dictionary containing Table objects representing the parsed CSV data.
-
-        Notes:
-            - If `file_name` is not provided, the main table name specified during initialization will be used.
-            - The `node_path` parameter is used for internal tracking during the recursive parsing process.
-            - The `parent_data` parameter allows for merging parent-level data into the current row.
-
-        &#34;&#34;&#34;
-        if not file_name:
-            file_name = self.main_table_name
-        if not node_path:
-            node_path = []
-        csv_file = self._create_csv_file(file_name)
-        if not parent_data:
-            parent_data = {}
-        for row in input_data:
-            if is_scalar(row):
-                row = {&#34;data&#34;: row}
-            if parent_data:
-                row.update(parent_data)
-                for key in parent_data:
-                    new_node_path = node_path + [key]
-                    self.analyzer.add_node(new_node_path, NodeType.SCALAR)
-            csv_row = self._parse_row(row, node_path)
-            csv_file.save_row(csv_row.get_row())
-            csv_file.headers = csv_row.get_headers()
-
-        return self._csv_file_results
-
-    def _parse_row(self,
-                   row: Dict[str, Any],
-                   current_path: Optional[List[str]] = None,
-                   outer_object_hash: Optional[str] = None) -&gt; CsvRow:
-        current_path = current_path or []
-        if self.analyze_further:
-            for name, value in row.items():
-                self.analyzer.analyze_object(current_path, name, value)
-        columns = self.analyzer.get_column_types(current_path)
-        array_parent_id = self._generate_column_hash(row, current_path, outer_object_hash)
-        primary_key_values = self._get_primary_key_values(data_row=row, node_path=current_path)
-        column_map = self.analyzer.get_column_mappings_at_path(current_path)
-        csv_row = CsvRow(column_map)
-        for column, (data_type, force_type) in dict(columns).items():
-            self._parse_field_by_type(row, csv_row, str(column), data_type, current_path, array_parent_id,
-                                      primary_key_values, force_type)
-        return csv_row
-
-    def _parse_field_by_type(self,
-                             row: Dict[str, Any],
-                             csv_row: CsvRow,
-                             column: str,
-                             data_type: NodeType,
-                             node_path: List[str],
-                             array_parent_id: str,
-                             primary_key_values: Dict[str, str],
-                             force_type: bool) -&gt; None:
-        &#34;&#34;&#34;
-            Parse a field of JSON data based on its data type and other properties.
-
-            This private method is responsible for parsing a field of JSON data based on its data type, node path,
-            and other properties like primary keys and force type.
-            It then stores the parsed value in the corresponding CSV row.
-
-            Parameters:
-                row (Dict[str, Any]): The JSON data for the current row.
-                csv_row (CsvRow): The CsvRow object representing the current row in the CSV.
-                column (str): The column name of the current field in the JSON data.
-                data_type (NodeType): The data type of the current field based on the node structure.
-                node_path (List[str]): The path to the current field in the JSON data.
-                array_parent_id (str): The ID of the parent object (for array elements) used for CSV table relations.
-                primary_key_values (Dict[str, str]): A dictionary containing primary key values for the table.
-                force_type (bool): A flag indicating whether to force the data to be unparsed.
-
-            Notes:
-                - If the column data is None, it tries to fetch the default value from the node in the analyzer.
-                - For lists and dictionaries, it calls the corresponding private methods to handle them recursively.
-                - For scalars or when force type is True, it sets the value directly in the CSV row.
-                - The `whole_path` variable is used for setting the value in the CSV row with the correct key
-                  (dot-separated).
-
-            &#34;&#34;&#34;
-
-        column_data = row.get(column)
-        if column_data is None:
-            path = node_path + [column]
-            node = self.analyzer.get_node_dict(path)
-            column_data = node.get(&#34;node&#34;).default_value
-
-        if column_data is None:
-            pass
-        elif data_type in [NodeType.LIST, NodeType.LIST_OF_DICTS, NodeType.LIST_OF_SCALARS] and not force_type:
-            self._parse_list_field(column_data, csv_row, node_path, column, array_parent_id, primary_key_values)
-        elif data_type == NodeType.DICT and not force_type:
-            # add primary_key_values to parse dict field?
-            self._parse_dict_field(column_data, csv_row, node_path, column, array_parent_id)
-        elif is_scalar(column_data) or force_type:
-            whole_path = node_path + [column]
-            csv_row.set_value(&#34;.&#34;.join(whole_path), column_data)
-
-    def _parse_list_field(self,
-                          column_data: Any,
-                          csv_row: CsvRow,
-                          node_path: List[str],
-                          column: str,
-                          array_parent_id: str,
-                          primary_key_values: Dict[str, str]) -&gt; None:
-        &#34;&#34;&#34;
-
-        Parse a list field of JSON data.
-
-        This private method is responsible for parsing a list field of JSON data, handling array elements, and
-        recursively processing the list items. It creates separate tables for each nested list,
-        maintains the parent-child relationship in the CSV data, and applies primary key values if available.
-
-        Parameters:
-            column_data (Any): The JSON data for the current column (list field).
-            csv_row (CsvRow): The CsvRow object representing the current row in the CSV.
-            node_path (List[str]): The path to the current field in the JSON data.
-            column (str): The column name of the current field in the JSON data.
-            array_parent_id (str): The ID of the parent object (for array elements) used for CSV table relations.
-            primary_key_values (Dict[str, str]): A dictionary containing primary key values for the table.
-
-        &#34;&#34;&#34;
-        if not is_list(column_data):
-            column_data = [column_data]
-        if array_parent_id or primary_key_values:
-            new_path = self.analyzer.create_path_to_child_object(node_path, column)
-            new_table_name = self.analyzer.get_table_name(new_path)
-            parent_data = {&#34;JSON_parentId&#34;: array_parent_id}
-            if primary_key_values:
-                parent_data = primary_key_values
-            else:
-                child_path = self.analyzer.create_path_to_child_object(node_path, column)
-                sf = self.analyzer.get_node_dict(child_path).get(&#34;node&#34;).header_name
-                csv_row.set_value(sf, array_parent_id)
-
-            self._parse_data(column_data, new_path, new_table_name, parent_data=parent_data)
-
-    def _parse_dict_field(self,
-                          column_data: Dict,
-                          csv_row: CsvRow,
-                          node_path: List[Union[Any, str]],
-                          column: str,
-                          array_parent_id: str) -&gt; None:
-
-        new_path = self.analyzer.create_path_to_child_object(node_path, column)
-        child_row = self._parse_row(column_data, new_path, outer_object_hash=array_parent_id)
-        for key, value in child_row.get_row().items():
-            csv_row.set_value(key, value)
-
-    def _create_csv_file(self, file_name: str) -&gt; Table:
-        if file_name not in self._csv_file_results:
-            self._csv_file_results[file_name] = Table(file_name, [])
-        return self._csv_file_results[file_name]
-
-    def _generate_column_hash(self, data_row: Dict[str, Any], node_path: List[Union[Any, str]],
-                              outer_object_hash: Optional[str] = None) -&gt; str:
-        node_path = [self.main_table_name] + node_path
-        clean_node_string = &#34;.&#34;.join(list(filter(lambda val: val != &#34;[]&#34;, node_path)))
-        hashed_values = hashlib.md5(str(data_row).encode() + str(outer_object_hash).encode()).hexdigest()
-        return f&#34;{clean_node_string}_{hashed_values}&#34;
-
-    def _get_primary_key_values(self, data_row: Dict[str, Any], node_path: List[Union[Any, str]]) -&gt; Dict[str, str]:
-        current_table_primary_keys = {}
-        children_nodes = self.analyzer.get_node_dict(path_to_object=node_path).get(&#34;children&#34;)
-        for child_node in children_nodes:
-            if children_nodes.get(child_node).get(&#34;node&#34;).is_primary_key:
-                # TODO FIX WHEN ID IS NESTED e.g. some_dict.id
-                name = &#34;_&#34;.join([self.main_table_name] + node_path + [child_node])
-                current_table_primary_keys[name] = data_row.get(child_node)
-
-        return current_table_primary_keys</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -344,20 +48,9 @@ class Parser:
 <dl>
 <dt id="keboola.json_to_csv.parser.Parser"><code class="flex name class">
 <span>class <span class="ident">Parser</span></span>
-<span>(</span><span>main_table_name: Optional[str] = None, table_mapping: Optional[<a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a>] = None, analyze_further: bool = True)</span>
+<span>(</span><span>main_table_name: str | None = None,<br>table_mapping: <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a> | None = None,<br>analyze_further: bool = True)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>JSON to CSV Parser.</p>
-<p>This class is responsible for converting JSON data to CSV files based on a specified table mapping.
-It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
-parsed CSV data to files.</p>
-<p>Initialize the JSON Parser.</p>
-<h2 id="parameters">Parameters</h2>
-<p>main_table_name (Optional[str]): The name of the main table to use for the CSV files.
-table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
-and force types.
-analyze_further (bool): If True, performs further analysis of data that is not specified
-in the table mapping.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -655,11 +348,21 @@ in the table mapping.</p></div>
 
         return current_table_primary_keys</code></pre>
 </details>
+<div class="desc"><p>JSON to CSV Parser.</p>
+<p>This class is responsible for converting JSON data to CSV files based on a specified table mapping.
+It provides methods for parsing JSON data, analyzing it to generate table mappings, and saving the
+parsed CSV data to files.</p>
+<p>Initialize the JSON Parser.</p>
+<h2 id="parameters">Parameters</h2>
+<p>main_table_name (Optional[str]): The name of the main table to use for the CSV files.
+table_mapping (Optional[TableMapping]): The mapping of tables and their columns, primary keys,
+and force types.
+analyze_further (bool): If True, performs further analysis of data that is not specified
+in the table mapping.</p></div>
 <h3>Instance variables</h3>
 <dl>
-<dt id="keboola.json_to_csv.parser.Parser.table_mapping"><code class="name">var <span class="ident">table_mapping</span> : <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
+<dt id="keboola.json_to_csv.parser.Parser.table_mapping"><code class="name">prop <span class="ident">table_mapping</span> : <a title="keboola.json_to_csv.mapping.TableMapping" href="mapping.html#keboola.json_to_csv.mapping.TableMapping">TableMapping</a></code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -669,23 +372,15 @@ def table_mapping(self) -&gt; TableMapping:
     table_mapping_dict = self.analyzer.get_mapping_dict_fom_structure()
     return TableMapping.build_from_mapping_dict(table_mapping_dict)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 </dl>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.parser.Parser.parse_data"><code class="name flex">
-<span>def <span class="ident">parse_data</span></span>(<span>self, input_data: Union[Dict, List[Dict]], root_name: Optional[str] = None) ‑> Dict</span>
+<span>def <span class="ident">parse_data</span></span>(<span>self, input_data: Dict | List[Dict], root_name: str | None = None) ‑> Dict</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Parse input data and return a dictionary of CSV rows as flat dictionaries.</p>
-<h2 id="parameters">Parameters</h2>
-<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>Dict</code></dt>
-<dd>A dictionary containing the parsed CSV data.</dd>
-</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -705,16 +400,20 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
     self._parse_data(data_to_parse)
     return {key: self._csv_file_results[key].rows for key in self._csv_file_results}</code></pre>
 </details>
-</dd>
-<dt id="keboola.json_to_csv.parser.Parser.parse_data_to_csv"><code class="name flex">
-<span>def <span class="ident">parse_data_to_csv</span></span>(<span>self, input_data: Union[Dict, List[Dict]], destination_path: str, root_name: Optional[str] = None) ‑> None</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Parse input data to CSV files and save them to the specified destination path.</p>
+<div class="desc"><p>Parse input data and return a dictionary of CSV rows as flat dictionaries.</p>
 <h2 id="parameters">Parameters</h2>
 <p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
-destination_path (str): The path to save the generated CSV files.
-root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p></div>
+root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Dict</code></dt>
+<dd>A dictionary containing the parsed CSV data.</dd>
+</dl></div>
+</dd>
+<dt id="keboola.json_to_csv.parser.Parser.parse_data_to_csv"><code class="name flex">
+<span>def <span class="ident">parse_data_to_csv</span></span>(<span>self,<br>input_data: Dict | List[Dict],<br>destination_path: str,<br>root_name: str | None = None) ‑> None</span>
+</code></dt>
+<dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -739,6 +438,11 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
             writer.writeheader()
             writer.writerows(table.rows)</code></pre>
 </details>
+<div class="desc"><p>Parse input data to CSV files and save them to the specified destination path.</p>
+<h2 id="parameters">Parameters</h2>
+<p>input_data (Union[Dict, List[Dict]]): The JSON data to parse.
+destination_path (str): The path to save the generated CSV files.
+root_name (Optional[str]): The root node name to use for parsing the data (default: None).</p></div>
 </dd>
 </dl>
 </dd>
@@ -746,7 +450,6 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -772,7 +475,7 @@ root_name (Optional[str]): The root node name to use for parsing the data (defau
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/table.html
+++ b/docs/table.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.table API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,56 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.table</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from typing import Any, Dict, List, Optional
-
-
-class Table:
-    &#34;&#34;&#34;
-    CSV Table Representation.
-
-    This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.
-
-    Attributes:
-        name (str): The name of the table.
-        headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).
-        rows (List[Dict[str, Any]]): A list of rows where each row is represented as a dictionary.
-
-    Methods:
-        __init__(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
-            Initialize a Table object.
-
-        save_row(self, row: Dict[str, Any]) -&gt; None:
-            Save a row of data to the Table.
-
-    &#34;&#34;&#34;
-
-    def __init__(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
-        &#34;&#34;&#34;
-        Initialize a Table object.
-
-        Parameters:
-            name (str): The name of the table.
-            headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).
-        &#34;&#34;&#34;
-        self.name = name
-        self.headers = headers or []
-        self.rows = []
-
-    def save_row(self, row: Dict[str, Any]) -&gt; None:
-        &#34;&#34;&#34;
-        Save a row of data to the Table.
-
-        This method appends a row of data represented as a dictionary to the list of rows in the Table.
-
-        Parameters:
-            row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.
-        &#34;&#34;&#34;
-        self.rows.append(row)</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -84,29 +48,9 @@ class Table:
 <dl>
 <dt id="keboola.json_to_csv.table.Table"><code class="flex name class">
 <span>class <span class="ident">Table</span></span>
-<span>(</span><span>name: str, headers: Optional[List[Any]] = None)</span>
+<span>(</span><span>name: str, headers: List[Any] | None = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>CSV Table Representation.</p>
-<p>This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the table.</dd>
-<dt><strong><code>headers</code></strong> :&ensp;<code>Optional[List[Any]]</code></dt>
-<dd>A list containing the headers of the CSV table (default: None).</dd>
-<dt><strong><code>rows</code></strong> :&ensp;<code>List[Dict[str, Any]]</code></dt>
-<dd>A list of rows where each row is represented as a dictionary.</dd>
-</dl>
-<h2 id="methods">Methods</h2>
-<p><strong>init</strong>(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
-Initialize a Table object.</p>
-<p>save_row(self, row: Dict[str, Any]) -&gt; None:
-Save a row of data to the Table.</p>
-<p>Initialize a Table object.</p>
-<h2 id="parameters">Parameters</h2>
-<p>name (str): The name of the table.
-headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -154,16 +98,32 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
         &#34;&#34;&#34;
         self.rows.append(row)</code></pre>
 </details>
+<div class="desc"><p>CSV Table Representation.</p>
+<p>This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the table.</dd>
+<dt><strong><code>headers</code></strong> :&ensp;<code>Optional[List[Any]]</code></dt>
+<dd>A list containing the headers of the CSV table (default: None).</dd>
+<dt><strong><code>rows</code></strong> :&ensp;<code>List[Dict[str, Any]]</code></dt>
+<dd>A list of rows where each row is represented as a dictionary.</dd>
+</dl>
+<h2 id="methods">Methods</h2>
+<p><strong>init</strong>(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
+Initialize a Table object.</p>
+<p>save_row(self, row: Dict[str, Any]) -&gt; None:
+Save a row of data to the Table.</p>
+<p>Initialize a Table object.</p>
+<h2 id="parameters">Parameters</h2>
+<p>name (str): The name of the table.
+headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.table.Table.save_row"><code class="name flex">
 <span>def <span class="ident">save_row</span></span>(<span>self, row: Dict[str, Any]) ‑> None</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Save a row of data to the Table.</p>
-<p>This method appends a row of data represented as a dictionary to the list of rows in the Table.</p>
-<h2 id="parameters">Parameters</h2>
-<p>row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -179,6 +139,10 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
     &#34;&#34;&#34;
     self.rows.append(row)</code></pre>
 </details>
+<div class="desc"><p>Save a row of data to the Table.</p>
+<p>This method appends a row of data represented as a dictionary to the list of rows in the Table.</p>
+<h2 id="parameters">Parameters</h2>
+<p>row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.</p></div>
 </dd>
 </dl>
 </dd>
@@ -186,7 +150,6 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -210,7 +173,7 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/table.html
+++ b/docs/table.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.table API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,56 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.table</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from typing import Any, Dict, List, Optional
+
+
+class Table:
+    &#34;&#34;&#34;
+    CSV Table Representation.
+
+    This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.
+
+    Attributes:
+        name (str): The name of the table.
+        headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).
+        rows (List[Dict[str, Any]]): A list of rows where each row is represented as a dictionary.
+
+    Methods:
+        __init__(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
+            Initialize a Table object.
+
+        save_row(self, row: Dict[str, Any]) -&gt; None:
+            Save a row of data to the Table.
+
+    &#34;&#34;&#34;
+
+    def __init__(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
+        &#34;&#34;&#34;
+        Initialize a Table object.
+
+        Parameters:
+            name (str): The name of the table.
+            headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).
+        &#34;&#34;&#34;
+        self.name = name
+        self.headers = headers or []
+        self.rows = []
+
+    def save_row(self, row: Dict[str, Any]) -&gt; None:
+        &#34;&#34;&#34;
+        Save a row of data to the Table.
+
+        This method appends a row of data represented as a dictionary to the list of rows in the Table.
+
+        Parameters:
+            row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.
+        &#34;&#34;&#34;
+        self.rows.append(row)</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -48,9 +84,29 @@ el.replaceWith(d);
 <dl>
 <dt id="keboola.json_to_csv.table.Table"><code class="flex name class">
 <span>class <span class="ident">Table</span></span>
-<span>(</span><span>name: str, headers: List[Any] | None = None)</span>
+<span>(</span><span>name: str, headers: Optional[List[Any]] = None)</span>
 </code></dt>
 <dd>
+<div class="desc"><p>CSV Table Representation.</p>
+<p>This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.</p>
+<h2 id="attributes">Attributes</h2>
+<dl>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The name of the table.</dd>
+<dt><strong><code>headers</code></strong> :&ensp;<code>Optional[List[Any]]</code></dt>
+<dd>A list containing the headers of the CSV table (default: None).</dd>
+<dt><strong><code>rows</code></strong> :&ensp;<code>List[Dict[str, Any]]</code></dt>
+<dd>A list of rows where each row is represented as a dictionary.</dd>
+</dl>
+<h2 id="methods">Methods</h2>
+<p><strong>init</strong>(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
+Initialize a Table object.</p>
+<p>save_row(self, row: Dict[str, Any]) -&gt; None:
+Save a row of data to the Table.</p>
+<p>Initialize a Table object.</p>
+<h2 id="parameters">Parameters</h2>
+<p>name (str): The name of the table.
+headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -98,32 +154,16 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         self.rows.append(row)</code></pre>
 </details>
-<div class="desc"><p>CSV Table Representation.</p>
-<p>This class represents a CSV table where the parsed data will be stored before saving it to a CSV file.</p>
-<h2 id="attributes">Attributes</h2>
-<dl>
-<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the table.</dd>
-<dt><strong><code>headers</code></strong> :&ensp;<code>Optional[List[Any]]</code></dt>
-<dd>A list containing the headers of the CSV table (default: None).</dd>
-<dt><strong><code>rows</code></strong> :&ensp;<code>List[Dict[str, Any]]</code></dt>
-<dd>A list of rows where each row is represented as a dictionary.</dd>
-</dl>
-<h2 id="methods">Methods</h2>
-<p><strong>init</strong>(self, name: str, headers: Optional[List[Any]] = None) -&gt; None:
-Initialize a Table object.</p>
-<p>save_row(self, row: Dict[str, Any]) -&gt; None:
-Save a row of data to the Table.</p>
-<p>Initialize a Table object.</p>
-<h2 id="parameters">Parameters</h2>
-<p>name (str): The name of the table.
-headers (Optional[List[Any]]): A list containing the headers of the CSV table (default: None).</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="keboola.json_to_csv.table.Table.save_row"><code class="name flex">
 <span>def <span class="ident">save_row</span></span>(<span>self, row: Dict[str, Any]) ‑> None</span>
 </code></dt>
 <dd>
+<div class="desc"><p>Save a row of data to the Table.</p>
+<p>This method appends a row of data represented as a dictionary to the list of rows in the Table.</p>
+<h2 id="parameters">Parameters</h2>
+<p>row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -139,10 +179,6 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
     &#34;&#34;&#34;
     self.rows.append(row)</code></pre>
 </details>
-<div class="desc"><p>Save a row of data to the Table.</p>
-<p>This method appends a row of data represented as a dictionary to the list of rows in the Table.</p>
-<h2 id="parameters">Parameters</h2>
-<p>row (Dict[str, Any]): A dictionary representing a single row of data to be saved in the Table.</p></div>
 </dd>
 </dl>
 </dd>
@@ -150,6 +186,7 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -173,7 +210,7 @@ headers (Optional[List[Any]]): A list containing the headers of the CSV table (d
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/utils.html
+++ b/docs/utils.html
@@ -2,32 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-<meta name="generator" content="pdoc3 0.11.6">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
 <title>keboola.json_to_csv.utils API documentation</title>
-<meta name="description" content="">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => {
-hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
-hljs.highlightAll();
-/* Collapse source docstrings */
-setTimeout(() => {
-[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
-.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
-.forEach(el => {
-let d = document.createElement('details');
-d.classList.add('hljs-string');
-d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
-el.replaceWith(d);
-});
-}, 100);
-})</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -36,6 +22,24 @@ el.replaceWith(d);
 <h1 class="title">Module <code>keboola.json_to_csv.utils</code></h1>
 </header>
 <section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from typing import Any
+
+
+def is_scalar(item: Any) -&gt; bool:
+    return isinstance(item, (int, float, str, bool))
+
+
+def is_dict(item: Any) -&gt; bool:
+    return isinstance(item, dict)
+
+
+def is_list(item: Any) -&gt; bool:
+    return isinstance(item, list)</code></pre>
+</details>
 </section>
 <section>
 </section>
@@ -48,6 +52,7 @@ el.replaceWith(d);
 <span>def <span class="ident">is_dict</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -55,12 +60,12 @@ el.replaceWith(d);
 <pre><code class="python">def is_dict(item: Any) -&gt; bool:
     return isinstance(item, dict)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.utils.is_list"><code class="name flex">
 <span>def <span class="ident">is_list</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -68,12 +73,12 @@ el.replaceWith(d);
 <pre><code class="python">def is_list(item: Any) -&gt; bool:
     return isinstance(item, list)</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.utils.is_scalar"><code class="name flex">
 <span>def <span class="ident">is_scalar</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -81,7 +86,6 @@ el.replaceWith(d);
 <pre><code class="python">def is_scalar(item: Any) -&gt; bool:
     return isinstance(item, (int, float, str, bool))</code></pre>
 </details>
-<div class="desc"></div>
 </dd>
 </dl>
 </section>
@@ -89,6 +93,7 @@ el.replaceWith(d);
 </section>
 </article>
 <nav id="sidebar">
+<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -109,7 +114,7 @@ el.replaceWith(d);
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
 </footer>
 </body>
 </html>

--- a/docs/utils.html
+++ b/docs/utils.html
@@ -2,18 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.10.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="generator" content="pdoc3 0.11.6">
 <title>keboola.json_to_csv.utils API documentation</title>
-<meta name="description" content="" />
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
-<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
-<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
-<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:1.5em;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:2em 0 .50em 0}h3{font-size:1.4em;margin:1.6em 0 .7em 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .2s ease-in-out}a:visited{color:#503}a:hover{color:#b62}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900;font-weight:bold}pre code{font-size:.8em;line-height:1.4em;padding:1em;display:block}code{background:#f3f3f3;font-family:"DejaVu Sans Mono",monospace;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source > summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible;min-width:max-content}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em 1em;margin:1em 0}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul ul{padding-left:1em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
-<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => {
+hljs.configure({languages: ['bash', 'css', 'diff', 'graphql', 'ini', 'javascript', 'json', 'plaintext', 'python', 'python-repl', 'rust', 'shell', 'sql', 'typescript', 'xml', 'yaml']});
+hljs.highlightAll();
+/* Collapse source docstrings */
+setTimeout(() => {
+[...document.querySelectorAll('.hljs.language-python > .hljs-string')]
+.filter(el => el.innerHTML.length > 200 && ['"""', "'''"].includes(el.innerHTML.substring(0, 3)))
+.forEach(el => {
+let d = document.createElement('details');
+d.classList.add('hljs-string');
+d.innerHTML = '<summary>"""</summary>' + el.innerHTML.substring(3);
+el.replaceWith(d);
+});
+}, 100);
+})</script>
 </head>
 <body>
 <main>
@@ -22,24 +36,6 @@
 <h1 class="title">Module <code>keboola.json_to_csv.utils</code></h1>
 </header>
 <section id="section-intro">
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">from typing import Any
-
-
-def is_scalar(item: Any) -&gt; bool:
-    return isinstance(item, (int, float, str, bool))
-
-
-def is_dict(item: Any) -&gt; bool:
-    return isinstance(item, dict)
-
-
-def is_list(item: Any) -&gt; bool:
-    return isinstance(item, list)</code></pre>
-</details>
 </section>
 <section>
 </section>
@@ -52,7 +48,6 @@ def is_list(item: Any) -&gt; bool:
 <span>def <span class="ident">is_dict</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -60,12 +55,12 @@ def is_list(item: Any) -&gt; bool:
 <pre><code class="python">def is_dict(item: Any) -&gt; bool:
     return isinstance(item, dict)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.utils.is_list"><code class="name flex">
 <span>def <span class="ident">is_list</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -73,12 +68,12 @@ def is_list(item: Any) -&gt; bool:
 <pre><code class="python">def is_list(item: Any) -&gt; bool:
     return isinstance(item, list)</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 <dt id="keboola.json_to_csv.utils.is_scalar"><code class="name flex">
 <span>def <span class="ident">is_scalar</span></span>(<span>item: Any) ‑> bool</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -86,6 +81,7 @@ def is_list(item: Any) -&gt; bool:
 <pre><code class="python">def is_scalar(item: Any) -&gt; bool:
     return isinstance(item, (int, float, str, bool))</code></pre>
 </details>
+<div class="desc"></div>
 </dd>
 </dl>
 </section>
@@ -93,7 +89,6 @@ def is_list(item: Any) -&gt; bool:
 </section>
 </article>
 <nav id="sidebar">
-<h1>Index</h1>
 <div class="toc">
 <ul></ul>
 </div>
@@ -114,7 +109,7 @@ def is_list(item: Any) -&gt; bool:
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.11.6</a>.</p>
 </footer>
 </body>
 </html>

--- a/src/keboola/json_to_csv/analyzer.py
+++ b/src/keboola/json_to_csv/analyzer.py
@@ -177,7 +177,7 @@ class Analyzer:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.DICT and real_type == NodeType.LIST_OF_DICTS:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
-        elif expected_type == NodeType.DICT and real_type in NodeType.LIST:
+        elif expected_type == NodeType.DICT and real_type == NodeType.LIST:
             self.upgrade_node_type(node, NodeType.LIST_OF_DICTS)
         elif expected_type == NodeType.SCALAR and real_type == NodeType.LIST_OF_SCALARS:
             self.upgrade_node_type(node, NodeType.LIST_OF_SCALARS)


### PR DESCRIPTION
# fix: use `==` instead of `in` for NodeType enum comparison

## Summary

Fixes a `TypeError: argument of type 'NodeType' is not iterable` crash in `Analyzer._perform_node_type_upgrade` (line 180 of `analyzer.py`).

The bug: `real_type in NodeType.LIST` uses the `in` operator against a single enum value, which Python cannot iterate over. Changed to `real_type == NodeType.LIST`, consistent with every other branch in the same method.

This is the root cause behind [SUPPORT-15504](https://keboola.atlassian.net/browse/SUPPORT-15504) — the Generic Extractor's "Infer Mapping" fails with an internal server error when the analyzer encounters a field that changes from `DICT` to `LIST` type across sample rows. A previous workaround in the Generic Extractor ([CFT-3031](https://linear.app/keboola/issue/CFT-3031)) covered some cases but not all.

**The only intentional code change is a single character on one line** (`in` → `==`). The `docs/*.html` changes are auto-regenerated by the repo's build tooling on push and are not part of this fix — please ignore them during review.

## Review & Testing Checklist for Human

- [ ] **Verify semantic intent of line 180**: confirm that matching only `NodeType.LIST` (not multiple list subtypes) is correct. Context: the preceding line 178 already handles `real_type == NodeType.LIST_OF_DICTS`, so this branch should only catch plain `LIST`. Every other branch in `_perform_node_type_upgrade` uses `==`.
- [ ] **Test with polymorphic JSON data**: reproduce the original bug by running Infer Mapping on a JSON response where the same field appears as a dict in one row and an empty list in another. Verify it no longer throws `TypeError`.
- [ ] **Consider adding a unit test** for the DICT→LIST upgrade path in `_perform_node_type_upgrade` — there is currently no test coverage for this specific branch.

### Notes
- Existing test suite (`test_parser.py`) passes. The functional test suite (`test_functional.py`) has a pre-existing collection error unrelated to this change.
- No CI is configured on this repository.
- Link to Devin session: https://app.devin.ai/sessions/cb968c61c84b4ee68c805852c52466a6
- Requested by: @Jakuboola

## Release Notes
**Justification, description**

Fix `TypeError: argument of type 'NodeType' is not iterable` in `_perform_node_type_upgrade` when a JSON field changes from dict to list type during analysis. Root cause of SUPPORT-15504.

**Plans for Customer Communication**

N/A — internal library fix, no user-facing configuration changes.

**Impact Analysis**

Low risk. Single-character fix (`in` → `==`) on a code path that was always broken (would throw TypeError). No behavioral change for any other code path.

**Deployment Plan**

Publish new version of `keboola-json-to-csv` to PyPI, then bump dependency in Generic Extractor.

**Rollback Plan**

Revert this one-line change.

**Post-Release Support Plan**

N/A

[SUPPORT-15504]: https://keboola.atlassian.net/browse/SUPPORT-15504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFT-3031]: https://keboola.atlassian.net/browse/CFT-3031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ