### PR TITLE
chore: bump version to 0.0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="keboola.json-to-csv",
-    version="0.0.12",
+    version="0.0.13",
     author="Keboola KDS Team",
     setup_requires=['flake8'],
     tests_require=[],


### PR DESCRIPTION
## Summary

Bumps the package version in `setup.py` from `0.0.12` to `0.0.13`.

The GitHub release `0.0.13` was created after merging PR #14 (the NodeType enum comparison fix for SUPPORT-15504), but the PyPI publish workflow failed with `400 Bad Request` because `setup.py` still declared version `0.0.12` — PyPI rejected the upload as a duplicate. The publish workflow builds the package using `setup.py`, so the version there must match the intended release.

## Review & Testing Checklist for Human

- [ ] After merging, **delete the existing `0.0.13` GitHub release and recreate it** (or re-run the failed `Upload Python Package` workflow) so that the publish job picks up the updated `setup.py` and successfully uploads `0.0.13` to PyPI
- [ ] Verify `0.0.13` appears on [PyPI](https://pypi.org/project/keboola.json-to-csv/#history) after the publish workflow completes

### Notes
- Link to Devin session: https://app.devin.ai/sessions/cb968c61c84b4ee68c805852c52466a6
- Requested by: @Jakuboola