### PR TITLE
fix: guard against None value in analyze_object when node type is DICT

### DIFF
--- a/docs/analyzer.html
+++ b/docs/analyzer.html
@@ -132,7 +132,7 @@ el.replaceWith(d);
                     self._perform_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type)
             real_node = self.get_node_dict(object_path)
 
-        if real_node[&#34;node&#34;].data_type == NodeType.DICT:
+        if real_node[&#34;node&#34;].data_type == NodeType.DICT and value is not None:
             for sub_obj_name, sub_obj_value in value.items():
                 self.analyze_object(object_path, sub_obj_name, sub_obj_value)
 
@@ -678,7 +678,7 @@ def is_nested_node_name(node_name: str) -&gt; bool:
                 self._perform_node_type_upgrade(expected_node.get(&#39;node&#39;), expected_type, real_type)
         real_node = self.get_node_dict(object_path)
 
-    if real_node[&#34;node&#34;].data_type == NodeType.DICT:
+    if real_node[&#34;node&#34;].data_type == NodeType.DICT and value is not None:
         for sub_obj_name, sub_obj_value in value.items():
             self.analyze_object(object_path, sub_obj_name, sub_obj_value)</code></pre>
 </details>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="keboola.json-to-csv",
-    version="0.0.13",
+    version="0.0.14",
     author="Keboola KDS Team",
     setup_requires=['flake8'],
     tests_require=[],

--- a/src/keboola/json_to_csv/analyzer.py
+++ b/src/keboola/json_to_csv/analyzer.py
@@ -84,7 +84,7 @@ class Analyzer:
                     self._perform_node_type_upgrade(expected_node.get('node'), expected_type, real_type)
             real_node = self.get_node_dict(object_path)
 
-        if real_node["node"].data_type == NodeType.DICT:
+        if real_node["node"].data_type == NodeType.DICT and value is not None:
             for sub_obj_name, sub_obj_value in value.items():
                 self.analyze_object(object_path, sub_obj_name, sub_obj_value)
 


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'NoneType' object has no attribute 'items'` in `analyzer.py:88` when a JSON field that was a dict in one row becomes `null` in a subsequent row during `analyze_object`.

When the analyzer encounters a field previously typed as `DICT` but with a `null` value in the current row, `_perform_node_type_upgrade` correctly leaves the node type as DICT (null shouldn't downgrade the schema). However, the code then unconditionally calls `value.items()` on the null value. This adds a `value is not None` guard to skip sub-object iteration when the value is null.

Also bumps version to `0.0.14` for PyPI release. The `docs/analyzer.html` change is auto-generated by CI.

## Review & Testing Checklist for Human

- [ ] **Verify the None guard is sufficient**: When `expected_type=DICT` and `real_type=NULL`, `_perform_node_type_upgrade` has no matching branch, so the node stays DICT. Confirm there's no other non-dict-like value type that could reach line 87 with `data_type == DICT` and crash on `.items()` (e.g., could a list or scalar slip through?).
- [ ] **No unit test was added** for this code path. `_perform_node_type_upgrade` and the null-value scenario have zero test coverage. Consider adding a test with JSON input like `[{"field": {"a": 1}}, {"field": null}]` to prevent regression.
- [ ] **End-to-end test**: After deploying `0.0.14` to GEX, test "Infer Mapping" with an API response where a field is a dict in some rows and `null` in others. Verify it no longer crashes.

### Notes
- Link to Devin session: https://app.devin.ai/sessions/cb968c61c84b4ee68c805852c52466a6
- Requested by: @Jakuboola
- Related: follows the `0.0.13` fix for SUPPORT-15504 (NodeType enum comparison bug). This is a second crash discovered in the same code path once the first fix unblocked it.